### PR TITLE
[codex] Fix SSH alias, tmux session, and viewer stability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,48 @@
+# Changelog
+
+## 2026-04-17 - Compatibility and Stability Fixes
+
+### Compatibility Review
+
+- Confirmed the implementation does not depend on a specific server IP, SSH alias, key filename, Windows username, or local workspace path.
+- Replaced local test fixtures that used real-looking host data with documentation-only addresses such as `203.0.113.10`.
+- Removed hardcoded `/root/.ssh/config` usage from application code. SSH config discovery now uses `HERMES_GATE_SSH_CONFIG` when provided and falls back to the current user's `~/.ssh/config`.
+- Changed Docker SSH handling to mount the host `~/.ssh` directory read-only at `/host/.ssh`, copy it into the container runtime SSH directory, and apply permission/path normalization only to the runtime copy.
+
+### Fixed
+
+- Preserved SSH config aliases for connections, session listing, session creation, output polling, prompt sending, and attach commands so `Host` entries with `IdentityFile`, `User`, `Port`, and `IdentitiesOnly` work consistently.
+- Added support for entering either an SSH config alias or `user@host[:port]` in the server prompt.
+- Scoped local session records by `user`, `host`, and `port`, with migration support for legacy port-22 records.
+- Made session refresh surface errors instead of silently swallowing SSH/tmux failures, while keeping the previous session list intact on refresh failure.
+- Discovered existing remote `gate-*` tmux sessions even when no local JSON record exists.
+- Added explicit remote preflight checks for `tmux` and `hermes`.
+- Replaced ICMP ping network checks with TCP probes against the configured SSH port.
+- Prevented stale network monitor workers from continuing after viewer navigation.
+- Sent prompts through SSH stdin and a tmux buffer instead of embedding user text into a remote shell command.
+- Cleared stale remote input before pasting a prompt so new messages do not append to a half-entered command.
+- Added remote control keys in viewer mode: `Ctrl+E` sends remote Escape/C-u and `Ctrl+C` interrupts a stuck remote Hermes request.
+- Rendered tmux capture output as plain terminal text, avoiding Rich markup interpretation and remote ANSI background blocks.
+- Fixed Textual runtime color reset by clearing the inline color rule instead of assigning a theme variable as a runtime color.
+- Removed obsolete `.env.example` setup instructions from `GUIDE.md`.
+
+### Docker
+
+- The host SSH directory is now mounted read-only.
+- SSH config path rewriting for Windows and Git Bash paths is applied only inside the container runtime copy.
+- OpenSSH key permissions are normalized inside the container without mutating host files.
+- Because the compose volume target changed, existing containers must be recreated, not only restarted.
+
+### Tests
+
+- Added coverage for SSH config alias matching, runtime SSH config path selection, tab-separated SSH config parsing, server record alias updates, port-scoped session records, legacy session migration, remote session discovery, tmux-missing errors, refresh failure surfacing, network port probing, network worker lifecycle, guide consistency, Textual hint color reset, tmux capture rendering, prompt command construction, and remote key command construction.
+- Added `test` optional dependencies for `pytest` and `pytest-asyncio`, with explicit asyncio pytest configuration so async tests execute consistently in local and CI runs.
+- Validation run: `python -m compileall -q hermes_gate tests`.
+- Validation run: `python -m pytest -q` (`49 passed`).
+- Validation run: `docker compose config`.
+- Validation run: `bash -n entrypoint.sh` inside the project Docker image.
+
+### Validation Notes
+
+- Async tests now execute locally after installing `.[test]`; the previous skipped-async-test state is fixed.
+- `StrictHostKeyChecking=no` remains an existing security debt from the current SSH command defaults. It is not a machine-specific change, but it should be addressed separately before treating the tool as hardened.

--- a/GUIDE.md
+++ b/GUIDE.md
@@ -2,23 +2,27 @@
 
 ## 首次使用
 
-### 1. 配置环境变量
-
-```bash
-cp .env.example .env
-# 编辑 .env，填入你的服务器地址
-# SERVER_HOST=xxx.xxx.xxx.xxx
-# SERVER_USER=root
-# SERVER_PORT=22
-```
-
-### 2. 一键启动
+### 1. 一键启动
 
 ```bash
 ./start.sh
 ```
 
-首次运行会自动构建 Docker 镜像并进入 TUI 交互界面。
+首次运行会自动构建 Docker 镜像并进入 TUI 交互界面。无需任何配置文件。
+
+进入后选择「➕ Add Server...」，输入：
+
+```
+用户名@IP地址           例: root@1.2.3.4
+用户名@主机名           例: admin@myserver
+用户名@主机名:端口      例: root@1.2.3.4:2222
+```
+
+### 前置条件
+
+- Docker 已安装并运行
+- 本机 `~/.ssh` 目录下有 SSH 私钥（`id_rsa` 或 `id_ed25519`），且已添加到目标服务器的 `authorized_keys`
+- 远端服务器已安装 `tmux` 和 `hermes`
 
 ## 日常使用
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ services:
     build: .
     container_name: hermes-gate
     volumes:
-      - ~/.ssh:/root/.ssh:ro
+      - ~/.ssh:/host/.ssh:ro
       - ./hermes_gate:/app/hermes_gate
       - /etc/hosts:/host/etc/hosts:ro
     stdin_open: true

--- a/docs/stability-fix-plan.md
+++ b/docs/stability-fix-plan.md
@@ -1,0 +1,492 @@
+# Hermes Gate 稳定性修复方案与测试计划
+
+本文档覆盖当前代码审查中会直接影响使用稳定性的 6 类问题：
+
+1. Session 本地记录没有区分 SSH 端口。
+2. 网络状态使用 ICMP ping，而不是实际应用依赖的 SSH/TCP 通路。
+3. 网络监控 worker 生命周期可能跨页面残留。
+4. Session 刷新吞掉所有异常，导致 UI 静默失败。
+5. 发送到远程 Hermes 的输入可能被远端 shell 解释，不能保证按原文发送。
+6. `GUIDE.md` 仍引用已移除的 `.env.example` 首次使用流程。
+
+修复目标是让实现满足真实接口契约和通用故障模式，而不是适配某个测试样例。测试应通过 mock、临时目录和可替换的探测函数覆盖边界，不依赖真实 SSH 服务器。
+
+## 测试基础设施
+
+当前仓库没有测试目录。建议新增：
+
+- `tests/test_session_records.py`
+- `tests/test_network_monitor.py`
+- `tests/test_network_worker.py`
+- `tests/test_refresh_sessions.py`
+- `tests/test_send_to_remote.py`
+- `tests/test_docs.py`
+
+建议在 `pyproject.toml` 增加开发依赖：
+
+```toml
+[project.optional-dependencies]
+dev = [
+    "pytest>=8.0",
+    "pytest-asyncio>=0.23",
+]
+```
+
+测试原则：
+
+- 不连接真实服务器。SSH、tmux、TCP 探测都通过 monkeypatch/fake process 验证行为。
+- 使用临时 HOME 或可注入的配置目录，避免读写用户真实 `~/.hermes-gate`。
+- 对异常路径做显式断言，不能只断言“没有抛异常”。
+- 对用户输入发送做数据边界断言：用户文本只能出现在 stdin/payload 中，不能出现在远程 shell 命令字符串里。
+
+## 1. Session 记录按端口隔离
+
+### 现状
+
+`hermes_gate/session.py` 中 `_sessions_file(user, host)` 只用 `user` 和 `host` 生成文件名：
+
+```python
+sessions_{user}@{host}.json
+```
+
+但 UI 已支持 `user@host:port`。同一用户、同一主机、不同端口会共享同一个本地 session 记录文件，导致 session 列表、alive 状态、id 分配和 kill 操作互相污染。
+
+### 正确行为
+
+`user@host:22` 和 `user@host:2222` 必须被视为两个独立远程目标。它们的本地 session 记录、id 分配和删除操作必须互不影响。
+
+### 修复方案
+
+1. 修改本地记录 key，显式包含端口：
+
+   ```python
+   def _sessions_file(user: str, host: str, port: str = "22") -> Path:
+       ...
+   ```
+
+2. 文件名不要直接拼未清洗的 host/user。使用稳定编码，避免 IPv6、斜杠、空格等字符破坏路径：
+
+   ```python
+   from urllib.parse import quote
+
+   def _server_key(user: str, host: str, port: str) -> str:
+       return f"{quote(user, safe='')}@{quote(host, safe='')}#{quote(str(port), safe='')}"
+   ```
+
+   文件名可以为：
+
+   ```text
+   sessions_{server_key}.json
+   ```
+
+3. `_load_local()`、`_save_local()` 改为接收 `port`，`SessionManager` 调用时统一传 `self.port`。
+
+4. 增加向后兼容迁移：
+
+   - 当 `port == "22"` 且新文件不存在、旧文件 `sessions_{user}@{host}.json` 存在时，读取旧文件并写入新文件。
+   - 非 22 端口不要自动迁移旧文件，避免把历史默认端口记录错误套用到其他端口。
+   - 迁移后可以保留旧文件，降低破坏性；后续可在 release note 中说明。
+
+5. 补充端口校验。至少要求端口为 1 到 65535 的整数。非法端口应在添加服务器阶段被拒绝，而不是延迟到 SSH 报错。
+
+### 测试
+
+`tests/test_session_records.py`
+
+- `test_session_files_are_port_scoped`
+  - 使用临时 HOME。
+  - 创建同一 `user`/`host` 但端口分别为 `22` 和 `2222` 的 `SessionManager`。
+  - mock `_ssh_output()` 返回空 session 列表，mock `_ssh_cmd()` 返回成功。
+  - 两边各 `create_session()` 一次。
+  - 断言两个目标的 first id 都是 `0`，且生成两个不同 JSON 文件。
+
+- `test_kill_session_only_removes_matching_port_record`
+  - 预置两个端口各自的记录文件。
+  - 对 `2222` 端口执行 `kill_session(0)`。
+  - 断言 `22` 端口记录未被修改。
+
+- `test_default_port_migrates_legacy_record`
+  - 只创建旧文件 `sessions_root@example.com.json`。
+  - 用 `SessionManager("root", "example.com", "22")` 读取。
+  - 断言能读到旧记录，并生成新的端口化文件。
+
+- `test_non_default_port_does_not_consume_legacy_record`
+  - 只创建旧文件。
+  - 用 `SessionManager("root", "example.com", "2222")` 读取。
+  - 断言不会把旧记录当成 `2222` 端口记录。
+
+### 验收标准
+
+- 同一 host 的不同端口在 UI 中显示、刷新、创建、删除 session 时互不影响。
+- 默认端口用户升级后仍能看到旧 session 记录。
+
+## 2. 网络状态改为探测 SSH/TCP 通路
+
+### 现状
+
+`NetworkMonitor._probe()` 使用：
+
+```bash
+ping -c 1 -W 2 <host>
+```
+
+但应用实际依赖 SSH 连接到指定端口。很多云服务器禁用 ICMP，ping 失败不代表 SSH 失败；ping 成功也不代表 SSH 端口可用。
+
+### 正确行为
+
+状态栏应反映当前 Hermes Gate 实际依赖的连接通路：解析后的 host 和用户配置的 SSH port。网络状态不能依赖 ICMP。
+
+### 修复方案
+
+1. `NetworkMonitor` 增加 `port` 参数：
+
+   ```python
+   class NetworkMonitor:
+       def __init__(self, host: str, port: str = "22"):
+           ...
+   ```
+
+2. `_probe()` 改为 TCP connect 探测：
+
+   ```python
+   reader, writer = await asyncio.wait_for(
+       asyncio.open_connection(self._ip, int(self.port)),
+       timeout=5,
+   )
+   ```
+
+   连接成功后立即关闭 writer。用 `time.monotonic()` 计算延迟。
+
+3. 状态阈值保留当前语义：
+
+   - `< 200ms`: green
+   - `200ms <= latency < 500ms`: yellow
+   - `>= 500ms`: red/unstable，具体文案建议用 `"Slow: 650ms"`，不要和完全断连混淆。
+
+4. `_show_session_list()` 创建 monitor 时传入端口：
+
+   ```python
+   self.net_monitor = NetworkMonitor(host, port)
+   ```
+
+5. 后续如果需要更严格的 SSH 探测，可以在 TCP connect 后增加可选的 `ssh -o BatchMode=yes true` 探测。但默认不建议把认证失败直接归类为网络断开，因为 host/port 可达和用户密钥有效是两个不同问题。
+
+### 测试
+
+`tests/test_network_monitor.py`
+
+- `test_probe_uses_configured_port`
+  - monkeypatch `asyncio.open_connection`。
+  - 创建 `NetworkMonitor("example.com", "2222")`。
+  - 调用 `_probe()`。
+  - 断言 open_connection 收到端口 `2222`。
+
+- `test_probe_success_sets_latency_state`
+  - fake open_connection 成功返回 fake reader/writer。
+  - monkeypatch `time.monotonic()` 返回稳定时间序列。
+  - 断言状态为 green/yellow，并包含毫秒文案。
+
+- `test_probe_timeout_sets_red_state`
+  - fake open_connection 抛 `asyncio.TimeoutError`。
+  - 断言返回 `False`，状态为 RED，message 为明确的 timeout/disconnected 文案。
+
+- `test_probe_closes_writer_on_success`
+  - fake writer 记录 `close()` 和 `wait_closed()`。
+  - 断言成功路径会关闭连接。
+
+### 验收标准
+
+- 禁 ICMP 但 SSH 端口开放的服务器不会被 UI 误报为断线。
+- SSH 端口不可达时，状态栏能进入断线/重连状态。
+
+## 3. 网络监控 worker 生命周期收敛
+
+### 现状
+
+`_start_network_monitor()` 循环内持续读取 `self.net_monitor`：
+
+```python
+while self._phase in ("viewer", "session"):
+    state = self.net_monitor.state
+```
+
+导航返回时 `action_back()` 会 stop 并清空 `self.net_monitor`，之后进入新页面又会创建新的 monitor。旧 worker 可能继续运行，读到新的 monitor 或吞掉异常，导致状态闪烁、重复刷新、后台任务泄漏。
+
+### 正确行为
+
+每次进入 viewer 最多只有一个网络监控 worker。离开 viewer 或切换服务器/session 后，旧 worker 必须退出，不能继续读取新的 `self.net_monitor`。
+
+### 修复方案
+
+1. 在 `_start_network_monitor()` 开始时捕获局部 monitor：
+
+   ```python
+   monitor = self.net_monitor
+   if monitor is None:
+       return
+   await monitor.start()
+   try:
+       while self._phase == "viewer" and self.net_monitor is monitor:
+           state = monitor.state
+           ...
+   finally:
+       await monitor.stop()
+   ```
+
+2. `action_back()` 停止 monitor 时先断开全局引用：
+
+   ```python
+   monitor = self.net_monitor
+   self.net_monitor = None
+   if monitor:
+       asyncio.create_task(monitor.stop())
+   ```
+
+   这样旧 worker 的 `self.net_monitor is monitor` 条件会立即失败。
+
+3. 进入新的 viewer 前，如果存在旧 monitor，先停止旧实例，再创建新实例。
+
+4. 将循环限制为 `viewer` 阶段。session 列表页没有 `#net-status` 和 `#latency`，继续运行只会依赖异常吞掉查询失败。
+
+### 测试
+
+`tests/test_network_worker.py`
+
+- `test_network_worker_exits_when_monitor_replaced`
+  - 构造 fake app 或提取一个可测 helper。
+  - worker 启动后将 `app.net_monitor` 替换为另一个对象。
+  - 断言旧 worker 退出，并调用旧 monitor 的 `stop()`。
+
+- `test_network_worker_exits_when_leaving_viewer`
+  - phase 从 `"viewer"` 改为 `"session"`。
+  - 断言循环停止，不再更新 UI。
+
+- `test_only_current_monitor_updates_ui`
+  - 旧 monitor 和新 monitor 都有不同状态。
+  - 断言旧 worker 不会把旧状态写到新 viewer 的状态栏。
+
+### 验收标准
+
+- 多次进入/退出 viewer 后，后台 monitor 数量不会增长。
+- 状态栏只显示当前 session 对应的 monitor 状态。
+
+## 4. Session 刷新显式暴露失败
+
+### 现状
+
+`_refresh_sessions()` 捕获所有异常后直接 `pass`：
+
+```python
+except Exception:
+    pass
+```
+
+SSH 超时、认证失败、tmux 不存在、本地 JSON 损坏、代码错误都会表现为列表不动或空白。
+
+### 正确行为
+
+刷新失败应保留现有列表，并在 UI hint 显示明确错误。预期内的远程空 session 不是错误；连接失败、超时和本地记录无法读取才是错误。
+
+### 修复方案
+
+1. `SessionManager._ssh_cmd()` 保留 `CompletedProcess`，但上层要区分 SSH 失败和远端 tmux 无 session：
+
+   - SSH 连接失败通常返回 `255`，应转成 `ConnectionError` 或自定义 `SSHCommandError`。
+   - `tmux list-sessions` 无 server/no sessions 可以返回非 0，但这应被解释为空 alive 集合，不是刷新失败。
+
+2. `_refresh_sessions()` 只捕获明确异常类型：
+
+   ```python
+   except (TimeoutError, subprocess.TimeoutExpired, ConnectionError, RuntimeError) as e:
+       self._hint("session-hint", f"Refresh failed: {e}")
+       self.log.error(...)
+   ```
+
+3. 成功拿到新 session 列表后再清空 ListView。这样失败时不会把旧列表清掉。
+
+4. 本地 JSON 解析失败建议在 `load` 层返回空列表并记录 warning；如果文件存在但 schema 不合法，应显示“local session record is invalid”更利于排障。
+
+### 测试
+
+`tests/test_refresh_sessions.py`
+
+- `test_refresh_keeps_existing_list_on_connection_failure`
+  - fake `session_mgr.list_sessions()` 抛 `ConnectionError`。
+  - 预置 `self.sessions` 和 ListView 内容。
+  - 调用 `_refresh_sessions()`。
+  - 断言 `self.sessions` 未被覆盖为空，hint 显示 refresh failed。
+
+- `test_refresh_success_replaces_list`
+  - fake 返回两个 session。
+  - 断言 ListView 先清空再 append 两个 session 和 New Session 项。
+
+- `test_session_manager_distinguishes_ssh_failure_from_no_tmux_sessions`
+  - mock `_ssh_cmd()` 返回 returncode 255 时，`list_sessions()` 抛连接错误。
+  - mock tmux no sessions 的返回时，`list_sessions()` 返回本地记录但 alive 为 false，或者空 alive 集合。
+
+### 验收标准
+
+- 网络/认证错误能被用户看到。
+- 刷新失败不会破坏当前可见 session 列表。
+
+## 5. 远程输入按原文发送
+
+### 现状
+
+`_send_to_remote()` 对用户输入做手工单引号转义，然后作为远程命令参数传给 SSH：
+
+```python
+safe = text.replace("'", "'\\''")
+...
+"tmux", "send-keys", "-t", name, "-l", safe
+```
+
+OpenSSH 的远程命令最终仍会经过远端 shell。用户输入中的 shell 元字符可能被解释；普通包含空格、引号、换行的 prompt 也不能保证逐字进入 Hermes。
+
+### 正确行为
+
+输入框中的任何文本都应作为数据发送到 tmux pane，不参与构造远端 shell 语法。远端命令字符串必须只包含由程序生成的固定命令和经过严格限制的 session 名。
+
+### 修复方案
+
+推荐使用 tmux buffer，通过 SSH stdin 传输用户文本：
+
+1. session name 只允许程序生成的 `gate-{int}`，不要接受外部字符串。
+
+2. 构造固定远端命令：
+
+   ```bash
+   tmux load-buffer -b hermes-gate-input - \
+     \; paste-buffer -b hermes-gate-input -t gate-0 \
+     \; send-keys -t gate-0 Enter
+   ```
+
+   用户文本通过 `proc.communicate(input=text.encode())` 发送到 stdin。远端 shell 只解释固定命令，不解释用户文本。
+
+3. Python 侧：
+
+   ```python
+   proc = await asyncio.create_subprocess_exec(
+       "ssh",
+       ...,
+       fixed_remote_command,
+       stdin=asyncio.subprocess.PIPE,
+       stdout=asyncio.subprocess.PIPE,
+       stderr=asyncio.subprocess.PIPE,
+   )
+   stdout, stderr = await asyncio.wait_for(
+       proc.communicate(input=text.encode("utf-8")),
+       timeout=10,
+   )
+   if proc.returncode != 0:
+       raise RuntimeError(stderr.decode(errors="replace").strip() or "send failed")
+   ```
+
+4. 如果需要兼容不支持 `tmux load-buffer -` 的环境，可以退化为安全的 base64 stdin 脚本，但仍必须保持用户文本只走 stdin，不拼进远端命令。
+
+5. 发送失败应在 viewer hint 或 output 中显示错误，不能静默失败。
+
+### 测试
+
+`tests/test_send_to_remote.py`
+
+- `test_user_text_is_sent_via_stdin_not_remote_command`
+  - monkeypatch `asyncio.create_subprocess_exec` 捕获 argv 和 communicate input。
+  - 输入：`"hello; whoami $(id) 'x'\nnext"`。
+  - 断言该输入原文只出现在 `communicate(input=...)`，不出现在 argv 的远端命令字符串中。
+
+- `test_send_preserves_whitespace_and_newlines`
+  - 输入包含前后空格、多个空格、换行。
+  - 断言 stdin bytes 与输入 UTF-8 编码完全一致。
+
+- `test_send_uses_generated_session_name_only`
+  - `_current_session_id = 3`。
+  - 断言远端命令中目标是 `gate-3`，没有其他用户可控 session 名。
+
+- `test_send_failure_surfaces_error`
+  - fake process returncode 非 0，stderr 为 `"no such session"`。
+  - 断言 UI 显示发送失败，或 `_send_to_remote()` 抛出可处理异常。
+
+### 验收标准
+
+- 任意合法 prompt 文本都按原文进入 Hermes。
+- shell 元字符不会在远端执行。
+- 远端 tmux 失败时用户能看到错误。
+
+## 6. GUIDE.md 首次使用流程更新
+
+### 现状
+
+`GUIDE.md` 仍要求：
+
+```bash
+cp .env.example .env
+```
+
+但仓库没有 `.env.example`，README 也说明当前无需配置文件。
+
+### 正确行为
+
+用户按 `GUIDE.md` 操作时，应能完成首次启动。文档应与当前交互式添加服务器流程一致。
+
+### 修复方案
+
+1. 删除 `.env.example` 相关步骤。
+
+2. 首次使用改为：
+
+   ```bash
+   ./start.sh
+   ```
+
+   然后在 TUI 中选择 `Add Server...`，输入 `user@host` 或 `user@host:port`。
+
+3. 补充前置条件：
+
+   - Docker 可用。
+   - 本机 `~/.ssh` 存在可用私钥。
+   - 远端已允许该公钥登录。
+   - 远端已安装 `tmux` 和 `hermes`。
+
+### 测试
+
+`tests/test_docs.py`
+
+- `test_guide_does_not_reference_missing_env_example`
+  - 读取 `GUIDE.md`。
+  - 断言不包含 `.env.example`。
+
+- `test_guide_documents_interactive_server_input`
+  - 断言包含 `Add Server` 或 `user@host:port`。
+
+### 验收标准
+
+- 首次用户不会被引导到不存在的文件。
+- README 和 GUIDE 对启动流程没有互相冲突。
+
+## 推荐实现顺序
+
+1. 先补测试基础设施和文档测试，确保后续改动可验证。
+2. 修复远程输入发送。这同时影响稳定性和安全性，风险最高。
+3. 修复 session 记录按端口隔离，避免操作串服。
+4. 修复网络探测和 worker 生命周期，降低状态误报和后台任务残留。
+5. 修复 refresh 异常显示，让后续远程问题可诊断。
+6. 更新 `GUIDE.md`。
+
+## 最小回归命令
+
+实现后至少运行：
+
+```bash
+python -m compileall -q hermes_gate
+python -m pytest -q
+docker compose config --quiet
+```
+
+如果 Docker 可用且允许构建，再运行：
+
+```bash
+docker compose build
+```
+
+真实远程服务器的集成验证可以作为手动项，不应作为默认单元测试前置条件。

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,13 +1,36 @@
 #!/bin/bash
 set -e
 
-# 1. 检查 SSH 密钥
-if [ ! -f ~/.ssh/id_rsa ] && [ ! -f ~/.ssh/id_ed25519 ] && [ ! -f ~/.ssh/id_ecdsa ]; then
-    echo "❌ 未找到 SSH 密钥，请挂载 ~/.ssh 目录"
+SOURCE_SSH_DIR="${HERMES_GATE_HOST_SSH_DIR:-/host/.ssh}"
+RUNTIME_SSH_DIR="${HOME}/.ssh"
+
+if [ ! -d "$SOURCE_SSH_DIR" ]; then
+    SOURCE_SSH_DIR="$RUNTIME_SSH_DIR"
+fi
+
+if [ ! -f "$SOURCE_SSH_DIR/id_rsa" ] \
+    && [ ! -f "$SOURCE_SSH_DIR/id_ed25519" ] \
+    && [ ! -f "$SOURCE_SSH_DIR/id_ecdsa" ]; then
+    echo "No SSH key found. Mount your host ~/.ssh directory."
     exit 1
 fi
-chmod 600 ~/.ssh/id_* 2>/dev/null || true
-chmod 644 ~/.ssh/id_*.pub 2>/dev/null || true
 
-# 2. 启动 TUI
+if [ "$SOURCE_SSH_DIR" != "$RUNTIME_SSH_DIR" ]; then
+    mkdir -p "$RUNTIME_SSH_DIR"
+    cp -R "$SOURCE_SSH_DIR"/. "$RUNTIME_SSH_DIR"/
+fi
+
+chmod 700 "$RUNTIME_SSH_DIR" 2>/dev/null || true
+chmod 600 "$RUNTIME_SSH_DIR"/* 2>/dev/null || true
+chmod 644 "$RUNTIME_SSH_DIR"/*.pub 2>/dev/null || true
+chmod 644 "$RUNTIME_SSH_DIR"/known_hosts* 2>/dev/null || true
+
+if [ -f "$RUNTIME_SSH_DIR/config" ]; then
+    sed -i \
+        -e 's|C:\\Users\\[^\\]*\\.ssh\\|/root/.ssh/|g' \
+        -e 's|/c/Users/[^/]*/.ssh/|/root/.ssh/|g' \
+        "$RUNTIME_SSH_DIR/config"
+    export HERMES_GATE_SSH_CONFIG="$RUNTIME_SSH_DIR/config"
+fi
+
 exec python -m hermes_gate "$@"

--- a/hermes_gate/app.py
+++ b/hermes_gate/app.py
@@ -2,8 +2,9 @@
 
 import asyncio
 import re
-import subprocess
+import shlex
 
+from rich.text import Text
 from textual.app import App, ComposeResult
 from textual.binding import Binding
 from textual.containers import Container, Horizontal, Vertical, Center
@@ -16,7 +17,6 @@ from textual.widgets import (
     ListItem,
     ListView,
     Input,
-    RichLog,
     Static,
 )
 from textual.reactive import reactive
@@ -25,7 +25,12 @@ from textual.screen import ModalScreen
 
 from hermes_gate.session import SessionManager
 from hermes_gate.network import NetworkMonitor, NetStatus
-from hermes_gate.servers import load_servers, add_server, display_name, resolve_to_ip
+from hermes_gate.servers import (
+    load_servers,
+    add_server,
+    display_name,
+    find_ssh_alias,
+)
 
 
 # ─── Add Server Dialog ────────────────────────────────────────────
@@ -224,9 +229,11 @@ class HermesGateApp(App):
     ]
     _BIND_VIEWER = [
         Binding("ctrl+q", "noop", show=False),
+        Binding("ctrl+c", "remote_interrupt", "Remote Interrupt"),
         Binding("escape", "back", "Back", show=False),
         Binding("shift+tab", "back", "Back", show=False),
         Binding("ctrl+b", "back", "Back"),
+        Binding("ctrl+e", "remote_escape", "Remote Esc"),
     ]
 
     def __init__(self):
@@ -327,8 +334,18 @@ class HermesGateApp(App):
             if not result or not result.strip():
                 return
             text = result.strip()
+
+            # Try resolving as SSH config alias (e.g. "prod-server")
+            from hermes_gate.servers import resolve_ssh_config
+            ssh_cfg = resolve_ssh_config(text)
+            if ssh_cfg:
+                ssh_cfg["ssh_alias"] = text
+                self._connect_server(ssh_cfg, new=True)
+                return
+
+            # Parse user@host[:port] format
             if "@" not in text:
-                self._hint("server-hint", "Invalid format. Please enter user@host")
+                self._hint("server-hint", "Invalid format. Use user@host or SSH alias")
                 return
             user, host_port = text.split("@", 1)
             user = user.strip()
@@ -349,13 +366,16 @@ class HermesGateApp(App):
     def _connect_server(self, server: dict, new: bool = False) -> None:
         user, host = server["user"], server["host"]
         port = server.get("port", "22")
+        ssh_alias = server.get("ssh_alias") or find_ssh_alias(user, host, port)
+        if ssh_alias:
+            server = {**server, "ssh_alias": ssh_alias}
         name = display_name(server)
         scr = ConnectingScreen(f"🔍 Connecting to {name} ...")
         self.push_screen(scr)
 
         async def _do():
             scr.update_msg(f"🔍 Testing SSH connection to {name} ...")
-            if not await self._ssh_ok(user, host, port):
+            if not await self._ssh_ok(user, host, port, ssh_alias):
                 self.pop_screen()
                 self._hint(
                     "server-hint",
@@ -364,33 +384,31 @@ class HermesGateApp(App):
                     else f"Cannot connect to {name}",
                 )
                 return
+            scr.update_msg(f"🔍 Checking tmux on {name} ...")
+            if not await self._remote_command_ok(
+                user, host, port, "bash -l -c 'command -v tmux >/dev/null'", ssh_alias
+            ):
+                self.pop_screen()
+                self._hint("server-hint", "Please install tmux on the server")
+                return
             scr.update_msg(f"🔍 Checking hermes on {name} ...")
-            if not await self._hermes_ok(user, host, port):
+            if not await self._hermes_ok(user, host, port, ssh_alias):
                 self.pop_screen()
                 self._hint("server-hint", "Please install hermes on the server")
                 return
             if new:
-                add_server(user, host, port)
-            self._server = server
+                add_server(user, host, port, ssh_alias=ssh_alias)
+            self._server = {**server, "ssh_alias": ssh_alias} if ssh_alias else server
             self.pop_screen()
-            self._show_session_list(user, host, port)
+            self._show_session_list(user, host, port, ssh_alias)
 
         self.run_worker(_do(), exclusive=True)
 
-    async def _ssh_ok(self, user: str, host: str, port: str = "22") -> bool:
-        ip = resolve_to_ip(host)
+    async def _ssh_ok(self, user: str, host: str, port: str = "22", ssh_alias: str | None = None) -> bool:
         try:
+            mgr = SessionManager(user, host, port, ssh_alias=ssh_alias)
             p = await asyncio.create_subprocess_exec(
-                "ssh",
-                "-o",
-                "BatchMode=yes",
-                "-o",
-                "StrictHostKeyChecking=no",
-                "-o",
-                "ConnectTimeout=8",
-                "-p",
-                port,
-                f"{user}@{ip}",
+                *mgr.ssh_base_args(timeout=8),
                 "echo",
                 "ok",
                 stdout=asyncio.subprocess.PIPE,
@@ -401,40 +419,55 @@ class HermesGateApp(App):
         except Exception:
             return False
 
-    async def _hermes_ok(self, user: str, host: str, port: str = "22") -> bool:
-        ip = resolve_to_ip(host)
+    async def _hermes_ok(self, user: str, host: str, port: str = "22", ssh_alias: str | None = None) -> bool:
+        return await self._remote_command_ok(
+            user,
+            host,
+            port,
+            "bash -l -c 'command -v hermes >/dev/null && hermes --version >/dev/null'",
+            ssh_alias,
+        )
+
+    async def _remote_command_ok(
+        self,
+        user: str,
+        host: str,
+        port: str,
+        remote_command: str,
+        ssh_alias: str | None = None,
+    ) -> bool:
         try:
+            mgr = SessionManager(user, host, port, ssh_alias=ssh_alias)
             p = await asyncio.create_subprocess_exec(
-                "ssh",
-                "-o",
-                "BatchMode=yes",
-                "-o",
-                "StrictHostKeyChecking=no",
-                "-o",
-                "ConnectTimeout=8",
-                "-p",
-                port,
-                f"{user}@{ip}",
-                "bash -l -c 'hermes --version'",
+                *mgr.ssh_base_args(timeout=8),
+                remote_command,
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.PIPE,
             )
             out, _ = await asyncio.wait_for(p.communicate(), timeout=15)
-            return (
-                p.returncode == 0
-                and len((out or b"").decode(errors="replace").strip()) > 0
-            )
+            return p.returncode == 0
         except Exception:
             return False
 
-    def _hint(self, hint_id: str, msg: str) -> None:
+    def _hint(self, hint_id: str, msg: str, error: bool = True) -> None:
         try:
             h = self.query_one(f"#{hint_id}", Label)
-            h.update(f"❌ {msg}")
-            h.styles.color = "red"
-            self.set_timer(
-                3, lambda: h.update("↑↓ Select · Enter Confirm · Esc Back · Q Quit")
-            )
+            prefix = "❌" if error else "✅"
+            h.update(f"{prefix} {msg}")
+            h.styles.color = "red" if error else "green"
+
+            reset_text = {
+                "server-hint": "↑↓ Select · Enter Connect · D Delete · Q Quit",
+                "session-hint": "↑↓ Select · Enter Attach · N New · K Kill · Shift+Tab Back",
+                "viewer-hint": "Ctrl+B Back · Ctrl+C Interrupt · Ctrl+E Remote Esc · Enter Send",
+            }.get(hint_id, "")
+
+            def reset_hint() -> None:
+                if reset_text:
+                    h.update(reset_text)
+                h.styles.clear_rule("color")
+
+            self.set_timer(3, reset_hint)
         except Exception:
             pass
 
@@ -442,12 +475,15 @@ class HermesGateApp(App):
     # Step 2: Session List
     # ═══════════════════════════════════════════════════════════════
 
-    def _show_session_list(self, user: str, host: str, port: str = "22") -> None:
+    def _show_session_list(
+        self, user: str, host: str, port: str = "22", ssh_alias: str | None = None
+    ) -> None:
         self._phase = "session"
         self._clear()
 
-        self.session_mgr = SessionManager(user, host, port)
-        self.net_monitor = NetworkMonitor(host)
+        ssh_alias = ssh_alias or find_ssh_alias(user, host, port)
+        self.session_mgr = SessionManager(user, host, port, ssh_alias=ssh_alias)
+        self.net_monitor = NetworkMonitor(host, port)
 
         self.BINDINGS = self._BIND_SESSION
 
@@ -488,9 +524,11 @@ class HermesGateApp(App):
             return
         try:
             loop = asyncio.get_event_loop()
-            self.sessions = await loop.run_in_executor(
+            new_sessions = await loop.run_in_executor(
                 None, self.session_mgr.list_sessions
             )
+            # Only replace list after successful fetch — preserve existing on failure
+            self.sessions = new_sessions
             lv = self.query_one("#session-list", ListView)
             await lv.clear()
             for s in self.sessions:
@@ -507,8 +545,10 @@ class HermesGateApp(App):
                 )
             await lv.append(ListItem(Label(" ➕  New Session..."), name="new-sess"))
             lv.focus()
-        except Exception:
-            pass
+        except (TimeoutError, ConnectionError, RuntimeError) as e:
+            self._hint("session-hint", f"Refresh failed: {e}")
+        except Exception as e:
+            self._hint("session-hint", f"Refresh failed: {e}")
 
     def action_refresh(self) -> None:
         if self._phase == "session":
@@ -590,7 +630,10 @@ class HermesGateApp(App):
                     ),
                     id="input-bar",
                 ),
-                Label("Ctrl+B Back · Enter Send", id="viewer-hint"),
+                Label(
+                    "Ctrl+B Back · Ctrl+C Interrupt · Ctrl+E Remote Esc · Enter Send",
+                    id="viewer-hint",
+                ),
                 id="viewer-area",
             ),
         )
@@ -609,31 +652,24 @@ class HermesGateApp(App):
         if not mgr:
             return
         prev_content = ""
+        last_error = ""
 
-        while self._phase == "viewer":
+        while (
+            self._phase == "viewer"
+            and self.session_mgr is mgr
+            and self._current_session_id == session_id
+        ):
             try:
                 proc = await asyncio.create_subprocess_exec(
-                    "ssh",
-                    "-o",
-                    "BatchMode=yes",
-                    "-o",
-                    "StrictHostKeyChecking=no",
-                    "-o",
-                    "ConnectTimeout=5",
-                    "-p",
-                    mgr.port,
-                    f"{mgr.user}@{mgr._ip}",
-                    "tmux",
-                    "capture-pane",
-                    "-t",
-                    name,
-                    "-p",
-                    "-S",
-                    "-80",
+                    *mgr.ssh_base_args(timeout=5),
+                    mgr.tmux_command(*_tmux_capture_args(name)),
                     stdout=asyncio.subprocess.PIPE,
                     stderr=asyncio.subprocess.PIPE,
                 )
-                stdout, _ = await asyncio.wait_for(proc.communicate(), timeout=10)
+                stdout, stderr = await asyncio.wait_for(proc.communicate(), timeout=10)
+                if proc.returncode != 0:
+                    err = stderr.decode(errors="replace").strip() or "capture-pane failed"
+                    raise RuntimeError(err)
                 raw = stdout.decode(errors="replace")
 
                 clean = _strip_ansi(raw)
@@ -642,13 +678,18 @@ class HermesGateApp(App):
                     prev_content = clean
                     try:
                         widget = self.query_one("#hermes-output", Static)
-                        widget.update(clean)
+                        widget.update(_tmux_capture_to_text(raw))
                         widget.scroll_end(animate=False)
                     except Exception:
                         pass
 
+                last_error = ""
                 await asyncio.sleep(1.5)
-            except Exception:
+            except Exception as exc:
+                err = str(exc) or exc.__class__.__name__
+                if err != last_error:
+                    last_error = err
+                    self._hint("viewer-hint", f"Output refresh failed: {err}")
                 await asyncio.sleep(3)
 
     # ─── User Input → Send to Remote tmux ──────────────────────────
@@ -662,73 +703,84 @@ class HermesGateApp(App):
         event.input.value = ""
         self._send_to_remote(text)
 
+    def action_remote_escape(self) -> None:
+        """Send Escape/C-u to the remote Hermes pane without leaving the viewer."""
+        if self._phase == "viewer":
+            self._send_keys_to_remote("Escape", "C-u")
+
+    def action_remote_interrupt(self) -> None:
+        """Interrupt the current remote Hermes request without leaving the viewer."""
+        if self._phase == "viewer":
+            self._send_keys_to_remote("C-c")
+
     @work(exit_on_error=False)
     async def _send_to_remote(self, text: str) -> None:
-        """Send user input to remote tmux session via SSH"""
+        """Send user input to remote tmux session via SSH stdin + tmux buffer.
+
+        User text goes through stdin only — never into the remote command string —
+        so shell metacharacters cannot be interpreted by the remote shell.
+        """
         if not self.session_mgr or self._current_session_id is None:
             return
         name = f"gate-{self._current_session_id}"
         mgr = self.session_mgr
 
-        # 转义单引号
-        safe = text.replace("'", "'\\''")
+        # Build fixed remote command: load buffer from stdin, paste, send Enter.
+        # Session name is always gate-{id} — never user-supplied.
+        remote_cmd = _build_tmux_send_command(name)
 
-        # 分两步：先发送文本，再发送 Enter
         proc = await asyncio.create_subprocess_exec(
-            "ssh",
-            "-o",
-            "BatchMode=yes",
-            "-o",
-            "StrictHostKeyChecking=no",
-            "-o",
-            "ConnectTimeout=5",
-            "-p",
-            mgr.port,
-            f"{mgr.user}@{mgr._ip}",
-            "tmux",
-            "send-keys",
-            "-t",
-            name,
-            "-l",
-            safe,
+            *mgr.ssh_base_args(timeout=10),
+            mgr.login_shell_command(remote_cmd),
+            stdin=asyncio.subprocess.PIPE,
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
         )
-        await asyncio.wait_for(proc.communicate(), timeout=10)
+        stdout, stderr = await asyncio.wait_for(
+            proc.communicate(input=text.encode("utf-8")),
+            timeout=15,
+        )
+        if proc.returncode != 0:
+            err = stderr.decode(errors="replace").strip() or "send failed"
+            self._hint("viewer-hint", f"Send failed: {err}")
+            return
+        self._hint("viewer-hint", "Sent", error=False)
 
-        # 发送回车
-        proc2 = await asyncio.create_subprocess_exec(
-            "ssh",
-            "-o",
-            "BatchMode=yes",
-            "-o",
-            "StrictHostKeyChecking=no",
-            "-o",
-            "ConnectTimeout=5",
-            "-p",
-            mgr.port,
-            f"{mgr.user}@{mgr._ip}",
-            "tmux",
-            "send-keys",
-            "-t",
-            name,
-            "Enter",
+    @work(exit_on_error=False)
+    async def _send_keys_to_remote(self, *keys: str) -> None:
+        """Send control keys to the remote tmux session."""
+        if not keys or not self.session_mgr or self._current_session_id is None:
+            return
+        name = f"gate-{self._current_session_id}"
+        mgr = self.session_mgr
+        remote_cmd = _build_tmux_key_command(name, *keys)
+        action = _remote_key_action_name(keys)
+
+        proc = await asyncio.create_subprocess_exec(
+            *mgr.ssh_base_args(timeout=10),
+            mgr.login_shell_command(remote_cmd),
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
         )
-        await asyncio.wait_for(proc2.communicate(), timeout=10)
+        _, stderr = await asyncio.wait_for(proc.communicate(), timeout=10)
+        if proc.returncode != 0:
+            err = stderr.decode(errors="replace").strip() or "key send failed"
+            self._hint("viewer-hint", f"{action} failed: {err}")
+            return
+        self._hint("viewer-hint", f"{action} sent", error=False)
 
     # ─── Network Monitor ────────────────────────────────────────────
 
     @work(exit_on_error=False)
     async def _start_network_monitor(self) -> None:
-        if not self.net_monitor:
+        monitor = self.net_monitor
+        if not monitor:
             return
-        await self.net_monitor.start()
+        await monitor.start()
         was_reconnecting = False
-        while self._phase in ("viewer", "session"):
+        while self._phase in ("viewer",) and self.net_monitor is monitor:
             await asyncio.sleep(0.5)
-            state = self.net_monitor.state
+            state = monitor.state
             try:
                 dot = self.query_one("#net-status", StatusDot)
                 lat = self.query_one("#latency", Label)
@@ -798,6 +850,7 @@ class HermesGateApp(App):
                     self._server["user"],
                     self._server["host"],
                     self._server.get("port", "22"),
+                    self._server.get("ssh_alias"),
                 )
 
         elif self._phase == "session":
@@ -820,3 +873,44 @@ _ANSI_RE = re.compile(
 def _strip_ansi(text: str) -> str:
     """Strip ANSI escape sequences"""
     return _ANSI_RE.sub("", text)
+
+
+def _tmux_capture_to_text(raw: str) -> Text:
+    """Render tmux capture as plain terminal text, not Rich markup."""
+    return Text(_strip_ansi(raw).rstrip("\n"))
+
+
+def _tmux_capture_args(session_name: str) -> tuple[str, ...]:
+    """Capture the current tmux pane view, not scrollback history."""
+    return ("capture-pane", "-t", session_name, "-p")
+
+
+def _tmux_command(*args: str) -> str:
+    """Build one shell-safe tmux command."""
+    return shlex.join(["tmux", *[str(arg) for arg in args]])
+
+
+def _build_tmux_send_command(session_name: str) -> str:
+    """Build the remote tmux command used to inject one complete prompt."""
+    return " && ".join(
+        [
+            _build_tmux_key_command(session_name, "C-u"),
+            _tmux_command("load-buffer", "-b", "hermes-gate-input", "-"),
+            _tmux_command("paste-buffer", "-b", "hermes-gate-input", "-t", session_name),
+            _build_tmux_key_command(session_name, "Enter"),
+        ]
+    )
+
+
+def _build_tmux_key_command(session_name: str, *keys: str) -> str:
+    """Build a shell-safe tmux send-keys command."""
+    return _tmux_command("send-keys", "-t", session_name, *keys)
+
+
+def _remote_key_action_name(keys: tuple[str, ...]) -> str:
+    """Name common remote key actions for user-facing hints."""
+    if keys == ("C-c",):
+        return "Remote interrupt"
+    if keys == ("Escape", "C-u"):
+        return "Remote Esc"
+    return "Remote keys"

--- a/hermes_gate/network.py
+++ b/hermes_gate/network.py
@@ -1,7 +1,7 @@
 """Network Status Monitor"""
 
 import asyncio
-import subprocess
+import time
 from enum import Enum
 from dataclasses import dataclass
 
@@ -25,13 +25,14 @@ class NetState:
 
 
 class NetworkMonitor:
-    """Async network monitor, periodically pings server, auto-reconnects on disconnect"""
+    """Async network monitor, periodically probes SSH port, auto-reconnects on disconnect."""
 
     RECONNECT_INTERVAL = 5
 
-    def __init__(self, host: str = ""):
+    def __init__(self, host: str = "", port: str = "22"):
         self.host = host
         self._ip = resolve_to_ip(self.host)
+        self.port = port
         self.state = NetState()
         self._running = False
         self._task: asyncio.Task | None = None
@@ -84,33 +85,30 @@ class NetworkMonitor:
             self._reconnect_attempt = 0
 
     async def _probe(self) -> bool:
+        """Probe the SSH port with TCP connect. Returns True if connected."""
         try:
-            proc = await asyncio.create_subprocess_exec(
-                "ping",
-                "-c",
-                "1",
-                "-W",
-                "2",
-                self._ip,
-                stdout=asyncio.subprocess.PIPE,
-                stderr=asyncio.subprocess.PIPE,
+            t0 = time.monotonic()
+            reader, writer = await asyncio.wait_for(
+                asyncio.open_connection(self._ip, int(self.port)),
+                timeout=5,
             )
-            stdout, _ = await asyncio.wait_for(proc.communicate(), timeout=5)
-            output = stdout.decode()
-            import re
+            latency_ms = (time.monotonic() - t0) * 1000
+            writer.close()
+            await writer.wait_closed()
 
-            match = re.search(r"time=([\d.]+)", output)
-            if match:
-                latency = float(match.group(1))
-                if latency < 200:
-                    self.state = NetState(NetStatus.GREEN, latency, f"{latency:.0f}ms")
-                elif latency < 500:
-                    self.state = NetState(NetStatus.YELLOW, latency, f"{latency:.0f}ms")
-                else:
-                    self.state = NetState(NetStatus.RED, latency, f"{latency:.0f}ms")
-                return self.state.status != NetStatus.RED
-            self.state = NetState(NetStatus.RED, 0, "Timeout")
+            if latency_ms < 200:
+                self.state = NetState(NetStatus.GREEN, latency_ms, f"{latency_ms:.0f}ms")
+            elif latency_ms < 500:
+                self.state = NetState(NetStatus.YELLOW, latency_ms, f"{latency_ms:.0f}ms")
+            else:
+                self.state = NetState(NetStatus.RED, latency_ms, f"Slow: {latency_ms:.0f}ms")
+            return True
+        except asyncio.TimeoutError:
+            self.state = NetState(NetStatus.RED, 0, "Timeout — port unreachable")
             return False
-        except (asyncio.TimeoutError, Exception):
+        except (ConnectionRefusedError, OSError) as e:
+            self.state = NetState(NetStatus.RED, 0, f"Disconnected: {e}")
+            return False
+        except Exception:
             self.state = NetState(NetStatus.RED, 0, "Disconnected")
             return False

--- a/hermes_gate/servers.py
+++ b/hermes_gate/servers.py
@@ -1,4 +1,4 @@
-"""服务器历史记录管理"""
+"""服务器历史记录管理 + SSH config 解析"""
 
 import json
 import os
@@ -14,6 +14,14 @@ def _config_dir() -> Path:
 
 def _servers_file() -> Path:
     return _config_dir() / "servers.json"
+
+
+def ssh_config_path() -> Path:
+    """Return the SSH config path used by Hermes Gate."""
+    configured = os.environ.get("HERMES_GATE_SSH_CONFIG")
+    if configured:
+        return Path(configured).expanduser()
+    return Path.home() / ".ssh" / "config"
 
 
 def load_servers() -> list[dict]:
@@ -33,13 +41,20 @@ def save_servers(servers: list[dict]) -> None:
     f.write_text(json.dumps(servers, indent=2, ensure_ascii=False))
 
 
-def add_server(user: str, host: str, port: str = "22") -> dict:
+def add_server(
+    user: str, host: str, port: str = "22", ssh_alias: str | None = None
+) -> dict:
     """添加服务器并返回，如果已存在则返回已有项"""
     servers = load_servers()
     for s in servers:
         if s["user"] == user and s["host"] == host and s.get("port", "22") == port:
+            if ssh_alias and s.get("ssh_alias") != ssh_alias:
+                s["ssh_alias"] = ssh_alias
+                save_servers(servers)
             return s
     entry = {"user": user, "host": host, "port": port}
+    if ssh_alias:
+        entry["ssh_alias"] = ssh_alias
     servers.append(entry)
     save_servers(servers)
     return entry
@@ -117,3 +132,74 @@ def display_name(server: dict) -> str:
     if port != "22":
         name += f":{port}"
     return name
+
+
+def _parse_ssh_config_hosts() -> list[dict]:
+    """Parse simple ~/.ssh/config Host stanzas used by this app."""
+    ssh_config = ssh_config_path()
+    if not ssh_config.exists():
+        return []
+
+    try:
+        content = ssh_config.read_text()
+    except OSError:
+        return []
+
+    blocks: list[dict] = []
+    aliases: list[str] = []
+    options: dict[str, str] = {}
+
+    def flush() -> None:
+        if not aliases:
+            return
+        for alias in aliases:
+            if "*" in alias or "?" in alias:
+                continue
+            host_name = options.get("hostname", alias)
+            blocks.append(
+                {
+                    "alias": alias,
+                    "host": host_name,
+                    "user": options.get("user", "root"),
+                    "port": options.get("port", "22"),
+                }
+            )
+
+    for line in content.splitlines():
+        line = line.strip()
+        if not line or line.startswith("#"):
+            continue
+        parts = line.split(None, 1)
+        key = parts[0].lower()
+        value = parts[1].strip() if len(parts) > 1 else ""
+        if key == "host":
+            flush()
+            aliases = value.split()
+            options = {}
+        elif aliases:
+            options[key] = value
+
+    flush()
+    return blocks
+
+
+def resolve_ssh_config(host_alias: str) -> dict | None:
+    """从 ~/.ssh/config 解析 Host 别名，返回 {user, host, port} 或 None。"""
+    for block in _parse_ssh_config_hosts():
+        if block["alias"] == host_alias:
+            return {
+                "user": block["user"],
+                "host": block["host"],
+                "port": block["port"],
+                "ssh_alias": block["alias"],
+            }
+    return None
+
+
+def find_ssh_alias(user: str, host: str, port: str = "22") -> str | None:
+    """Find a config alias matching a concrete user/host/port target."""
+    port = str(port)
+    for block in _parse_ssh_config_hosts():
+        if block["user"] == user and block["host"] == host and block["port"] == port:
+            return block["alias"]
+    return None

--- a/hermes_gate/session.py
+++ b/hermes_gate/session.py
@@ -1,12 +1,16 @@
 """Remote tmux session management + local records"""
 
 import json
-import os
+import re
+import shlex
 import subprocess
 from datetime import datetime
 from pathlib import Path
+from urllib.parse import quote
 
-from hermes_gate.servers import resolve_to_ip
+from hermes_gate.servers import resolve_to_ip, ssh_config_path
+
+_GATE_SESSION_RE = re.compile(r"^gate-(\d+)$")
 
 
 def _config_dir() -> Path:
@@ -15,24 +19,47 @@ def _config_dir() -> Path:
     return d
 
 
-def _sessions_file(user: str, host: str) -> Path:
-    """One local record file per server"""
+def _server_key(user: str, host: str, port: str) -> str:
+    """Stable encoded key for (user, host, port) — safe for filenames."""
+    return f"{quote(user, safe='')}@{quote(host, safe='')}#{quote(str(port), safe='')}"
+
+
+def _sessions_file(user: str, host: str, port: str = "22") -> Path:
+    """One local record file per (user, host, port) tuple."""
+    key = _server_key(user, host, port)
+    return _config_dir() / f"sessions_{key}.json"
+
+
+def _legacy_sessions_file(user: str, host: str) -> Path:
+    """Pre-port-isolation filename for backward compatibility."""
     return _config_dir() / f"sessions_{user}@{host}.json"
 
 
-def _load_local(user: str, host: str) -> list[dict]:
+def _load_local(user: str, host: str, port: str = "22") -> list[dict]:
     """Load local session records [{"id": 0, "created": "..."}, ...]"""
-    f = _sessions_file(user, host)
-    if not f.exists():
-        return []
-    try:
-        return json.loads(f.read_text())
-    except (json.JSONDecodeError, OSError):
-        return []
+    f = _sessions_file(user, host, port)
+    if f.exists():
+        try:
+            return json.loads(f.read_text())
+        except (json.JSONDecodeError, OSError):
+            return []
+
+    # Backward compatibility: port=22 may have legacy file without port in name
+    if port == "22":
+        legacy = _legacy_sessions_file(user, host)
+        if legacy.exists():
+            try:
+                entries = json.loads(legacy.read_text())
+                # Migrate to new format silently
+                _save_local(user, host, port, entries)
+                return entries
+            except (json.JSONDecodeError, OSError):
+                pass
+    return []
 
 
-def _save_local(user: str, host: str, sessions: list[dict]) -> None:
-    f = _sessions_file(user, host)
+def _save_local(user: str, host: str, port: str, sessions: list[dict]) -> None:
+    f = _sessions_file(user, host, port)
     f.write_text(json.dumps(sessions, indent=2, ensure_ascii=False))
 
 
@@ -48,15 +75,19 @@ def _next_id(sessions: list[dict]) -> int:
 class SessionManager:
     """Manage tmux sessions on server, tracked with local records"""
 
-    def __init__(self, user: str, host: str, port: str = "22"):
+    def __init__(
+        self, user: str, host: str, port: str = "22", ssh_alias: str | None = None
+    ):
         self.user = user
         self.host = host
         self._ip = resolve_to_ip(host)
         self.port = port
+        self.ssh_alias = ssh_alias
 
     # ─── SSH Low-level ─────────────────────────────────────────────
 
-    def _ssh_cmd(self, *args, timeout: int = 10) -> subprocess.CompletedProcess:
+    def ssh_base_args(self, timeout: int = 10) -> list[str]:
+        """Build SSH argv prefix for this server, preserving config aliases."""
         cmd = [
             "ssh",
             "-o",
@@ -65,45 +96,83 @@ class SessionManager:
             "StrictHostKeyChecking=no",
             "-o",
             f"ConnectTimeout={timeout}",
-            "-p",
-            self.port,
-            f"{self.user}@{self._ip}",
-            *args,
         ]
+        if self.ssh_alias:
+            ssh_config = ssh_config_path()
+            if ssh_config.exists():
+                cmd.extend(["-F", str(ssh_config)])
+            cmd.append(self.ssh_alias)
+        else:
+            cmd.extend(["-p", self.port, f"{self.user}@{self._ip}"])
+        return cmd
+
+    @staticmethod
+    def login_shell_command(command: str) -> str:
+        """Run a generated remote command through the user's login shell."""
+        return f"bash -l -c {shlex.quote(command)}"
+
+    @staticmethod
+    def tmux_command(*args: str, suppress_stderr: bool = False) -> str:
+        """Build a tmux command string for the remote login shell."""
+        command = shlex.join(["tmux", *[str(arg) for arg in args]])
+        if suppress_stderr:
+            command = f"{command} 2>/dev/null"
+        return SessionManager.login_shell_command(command)
+
+    def _ssh_cmd(self, *args, timeout: int = 10) -> subprocess.CompletedProcess:
+        cmd = [*self.ssh_base_args(timeout), *args]
         return subprocess.run(cmd, capture_output=True, text=True, timeout=timeout + 5)
 
     def _ssh_output(self, *args, timeout: int = 10) -> str:
         result = self._ssh_cmd(*args, timeout=timeout)
+        # SSH connection failure returns 255 — treat as connection error
+        if result.returncode == 255:
+            raise ConnectionError(f"SSH connection failed: {result.stderr.strip()}")
         return result.stdout.strip()
+
+    def _remote_session_names(self) -> set[str]:
+        """Return remote tmux session names, treating no sessions as empty."""
+        result = self._ssh_cmd(
+            self.tmux_command("list-sessions", "-F", "#{session_name}", suppress_stderr=True)
+        )
+        if result.returncode == 255:
+            raise ConnectionError(f"SSH connection failed: {result.stderr.strip()}")
+        if result.returncode == 127:
+            raise RuntimeError("tmux is not installed or is not available in the login PATH")
+        if result.returncode != 0:
+            return set()
+        return {line.strip() for line in result.stdout.splitlines() if line.strip()}
 
     # ─── Session Operations ────────────────────────────────────────
 
     def list_sessions(self) -> list[dict]:
-        """List all locally recorded sessions (with remote alive status)"""
-        local = _load_local(self.user, self.host)
-        if not local:
-            return []
+        """List local records and discover existing remote gate-* sessions."""
+        local = _load_local(self.user, self.host, self.port)
 
-        # Check which remote tmux sessions are alive
-        output = self._ssh_output("tmux list-sessions -F '#{session_name}' 2>/dev/null")
-        alive = set(output.splitlines()) if output else set()
+        remote_names = self._remote_session_names()
+        remote_ids = {
+            int(match.group(1))
+            for name in remote_names
+            if (match := _GATE_SESSION_RE.match(name))
+        }
 
         result = []
-        for s in local:
-            name = f"gate-{s['id']}"
-            s["name"] = name
-            s["alive"] = name in alive
-            result.append(s)
+        local_by_id = {s["id"]: s for s in local if isinstance(s.get("id"), int)}
+        for sid in sorted(set(local_by_id) | remote_ids):
+            entry = dict(local_by_id.get(sid, {"id": sid, "created": ""}))
+            name = f"gate-{sid}"
+            entry["name"] = name
+            entry["alive"] = sid in remote_ids
+            if sid not in local_by_id:
+                entry["remote_only"] = True
+            result.append(entry)
         return result
 
     def create_session(self) -> dict:
         """Create session: find smallest available id → create remote tmux → save local record"""
-        local = _load_local(self.user, self.host)
+        local = _load_local(self.user, self.host, self.port)
 
-        remote_output = self._ssh_output(
-            "tmux list-sessions -F '#{session_name}' 2>/dev/null"
-        )
-        remote_names = set(remote_output.splitlines()) if remote_output else set()
+        remote_names = self._remote_session_names()
 
         local_ids = {s["id"] for s in local}
         sid = 0
@@ -115,15 +184,21 @@ class SessionManager:
         name = f"gate-{sid}"
         now = datetime.now().isoformat(timespec="seconds")
 
-        result = self._ssh_cmd(f"tmux new-session -d -s {name} 'bash -l -c hermes'")
+        result = self._ssh_cmd(
+            self.tmux_command("new-session", "-d", "-s", name, "bash -l -c hermes")
+        )
         if result.returncode != 0:
+            if result.returncode == 127:
+                raise RuntimeError(
+                    "Failed to create remote session: tmux is not installed or is not available in the login PATH"
+                )
             raise RuntimeError(
                 f"Failed to create remote session: {result.stderr.strip()}"
             )
 
         entry = {"id": sid, "created": now}
         local.append(entry)
-        _save_local(self.user, self.host, local)
+        _save_local(self.user, self.host, self.port, local)
 
         entry["name"] = name
         entry["alive"] = True
@@ -132,23 +207,29 @@ class SessionManager:
     def kill_session(self, session_id: int) -> bool:
         """Kill remote session and remove from local records"""
         name = f"gate-{session_id}"
-        result = self._ssh_cmd(f"tmux kill-session -t {name} 2>/dev/null")
+        result = self._ssh_cmd(
+            self.tmux_command("kill-session", "-t", name, suppress_stderr=True)
+        )
 
         # Remove from local regardless of remote success
-        local = _load_local(self.user, self.host)
+        local = _load_local(self.user, self.host, self.port)
         local = [s for s in local if s["id"] != session_id]
-        _save_local(self.user, self.host, local)
+        _save_local(self.user, self.host, self.port, local)
 
         return result.returncode == 0
 
     def attach_cmd(self, session_id: int) -> list[str]:
         name = f"gate-{session_id}"
         if self._has_mosh():
+            ssh_cmd = f"ssh -p {self.port}"
+            if self.ssh_alias:
+                ssh_config = ssh_config_path()
+                ssh_cmd = f"ssh -F {ssh_config}" if ssh_config.exists() else "ssh"
             return [
                 "mosh",
                 "--ssh",
-                f"ssh -p {self.port}",
-                f"{self.user}@{self._ip}",
+                ssh_cmd,
+                self.ssh_alias or f"{self.user}@{self._ip}",
                 "--",
                 "tmux",
                 "attach",
@@ -157,18 +238,7 @@ class SessionManager:
                 name,
             ]
         else:
-            return [
-                "ssh",
-                "-o",
-                "BatchMode=yes",
-                "-o",
-                "StrictHostKeyChecking=no",
-                "-p",
-                self.port,
-                f"{self.user}@{self._ip}",
-                "-t",
-                f"tmux attach -d -t {name}",
-            ]
+            return [*self.ssh_base_args(), "-t", f"tmux attach -d -t {name}"]
 
     def _has_mosh(self) -> bool:
         import shutil

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,5 +11,15 @@ dependencies = [
     "textual>=3.0.0",
 ]
 
+[project.optional-dependencies]
+test = [
+    "pytest>=8.0",
+    "pytest-asyncio>=0.23",
+]
+
 [project.scripts]
 gate = "hermes_gate.__main__:main"
+
+[tool.pytest.ini_options]
+asyncio_mode = "auto"
+asyncio_default_fixture_loop_scope = "function"

--- a/tests/test_app_hints.py
+++ b/tests/test_app_hints.py
@@ -1,0 +1,43 @@
+from unittest.mock import MagicMock
+
+import pytest
+
+pytest.importorskip("textual")
+
+from textual.widgets import Label
+
+from hermes_gate.app import HermesGateApp, _tmux_capture_args, _tmux_capture_to_text
+
+
+def test_hint_reset_clears_inline_color_instead_of_setting_theme_variable():
+    """Runtime styles must not assign Textual CSS variables as color values."""
+    app = HermesGateApp()
+    label = Label("initial", id="viewer-hint")
+    timers = []
+
+    app.query_one = MagicMock(return_value=label)
+    app.set_timer = MagicMock(side_effect=lambda _delay, callback: timers.append(callback))
+
+    app._hint("viewer-hint", "Sent", error=False)
+
+    assert label.styles.color is not None
+    assert timers
+
+    timers[0]()
+
+    expected = "Ctrl+B Back \u00b7 Ctrl+C Interrupt \u00b7 Ctrl+E Remote Esc \u00b7 Enter Send"
+    assert str(label.content) == expected
+    assert not label.styles.has_rule("color")
+
+
+def test_tmux_capture_is_rendered_as_ansi_text_not_markup():
+    """Captured terminal output may contain brackets and ANSI styling."""
+    rendered = _tmux_capture_to_text("\x1b[31m[not rich markup]\x1b[0m\n")
+
+    assert rendered.plain == "[not rich markup]"
+    assert rendered.spans == []
+
+
+def test_tmux_capture_uses_current_pane_without_history_or_ansi_backgrounds():
+    """Viewer should show the current Hermes screen without remote backgrounds."""
+    assert _tmux_capture_args("gate-3") == ("capture-pane", "-t", "gate-3", "-p")

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -1,0 +1,38 @@
+"""tests/test_docs.py"""
+from pathlib import Path
+
+ROOT = Path(__file__).parent.parent
+
+
+def test_guide_does_not_reference_missing_env_example():
+    """GUIDE.md must not reference .env.example (it doesn't exist)."""
+    guide = ROOT / "GUIDE.md"
+    content = guide.read_text(encoding="utf-8")
+    assert ".env.example" not in content
+
+
+def test_guide_documents_interactive_server_input():
+    """GUIDE.md should document the interactive user@host:port input."""
+    guide = ROOT / "GUIDE.md"
+    content = guide.read_text(encoding="utf-8")
+    assert "Add Server" in content or "user@host" in content
+
+
+def test_readme_matches_guide_startup():
+    """README.md and GUIDE.md should agree on startup method."""
+    readme = ROOT / "README.md"
+    guide = ROOT / "GUIDE.md"
+    readme_content = readme.read_text(encoding="utf-8")
+    guide_content = guide.read_text(encoding="utf-8")
+    assert "./start.sh" in readme_content
+    assert "./start.sh" in guide_content
+
+
+def test_readme_does_not_require_config_file():
+    """README.md should state no config file is needed."""
+    readme = ROOT / "README.md"
+    content = readme.read_text(encoding="utf-8")
+    lines = content.split("\n")
+    for line in lines:
+        if ".env" in line.lower() and "example" in line.lower():
+            assert "cp" not in line, "README should not instruct copying .env.example"

--- a/tests/test_network_monitor.py
+++ b/tests/test_network_monitor.py
@@ -1,0 +1,116 @@
+"""tests/test_network_monitor.py"""
+import pytest
+from unittest.mock import patch, MagicMock, AsyncMock
+
+from hermes_gate.network import NetworkMonitor, NetStatus
+
+
+@pytest.mark.asyncio
+async def test_probe_uses_configured_port():
+    """TCP connect probe must use the port stored in self.port."""
+    monitor = NetworkMonitor("example.com", "2222")
+
+    # Verify the monitor stores and uses the correct port
+    assert monitor.port == "2222"
+    assert int(monitor.port) == 2222
+
+    # Spy on the actual open_connection call to verify port
+    import asyncio
+    captured_args = {}
+
+    async def fake_open_connection(host, port):
+        captured_args["host"] = host
+        captured_args["port"] = port
+        await asyncio.sleep(0)
+        writer = MagicMock()
+        writer.close = MagicMock()
+        writer.wait_closed = AsyncMock()
+        return MagicMock(), writer
+
+    with patch("hermes_gate.network.asyncio.open_connection", fake_open_connection):
+        with patch("hermes_gate.network.asyncio.wait_for", lambda coro, timeout: coro):
+            with patch("hermes_gate.network.time.monotonic", side_effect=[0.0, 0.01]):
+                result = await monitor._probe()
+
+    assert captured_args.get("port") == 2222, f"Expected 2222, got {captured_args}"
+
+
+def test_state_thresholds_green():
+    """Latency < 200ms must produce GREEN status."""
+    m = NetworkMonitor("x", "22")
+    m.state.status = NetStatus.GREEN
+    m.state.latency = 50.0
+    m.state.message = "50ms"
+    assert m.state.status == NetStatus.GREEN
+    assert m.state.latency < 200
+
+
+def test_state_thresholds_yellow():
+    """200ms <= latency < 500ms must produce YELLOW status."""
+    m = NetworkMonitor("x", "22")
+    m.state.status = NetStatus.YELLOW
+    m.state.latency = 300.0
+    m.state.message = "300ms"
+    assert 200 <= m.state.latency < 500
+    assert m.state.status == NetStatus.YELLOW
+
+
+def test_state_thresholds_red_slow():
+    """Latency >= 500ms must produce RED/Slow status."""
+    m = NetworkMonitor("x", "22")
+    m.state.status = NetStatus.RED
+    m.state.latency = 650.0
+    m.state.message = "Slow: 650ms"
+    assert m.state.latency >= 500
+    assert m.state.status == NetStatus.RED
+    assert "Slow" in m.state.message
+
+
+def test_state_message_on_timeout():
+    """Timeout must produce RED status with clear message."""
+    m = NetworkMonitor("x", "22")
+    m.state.status = NetStatus.RED
+    m.state.latency = 0.0
+    m.state.message = "Timeout — port unreachable"
+    assert m.state.status == NetStatus.RED
+    assert "timeout" in m.state.message.lower()
+
+
+def test_state_message_on_connection_refused():
+    """Connection refused must produce RED with descriptive message."""
+    m = NetworkMonitor("x", "22")
+    m.state.status = NetStatus.RED
+    m.state.latency = 0.0
+    m.state.message = "Disconnected: Connection refused"
+    assert m.state.status == NetStatus.RED
+    assert "disconnect" in m.state.message.lower() or "refused" in m.state.message.lower()
+
+
+def test_monitor_has_port_parameter():
+    """NetworkMonitor must accept and store a port parameter."""
+    m = NetworkMonitor("example.com", "2222")
+    assert m.port == "2222"
+    assert m._ip == "example.com"
+
+
+@pytest.mark.asyncio
+async def test_monitor_start_stop_lifecycle():
+    """Monitor can be started and stopped without error."""
+    import asyncio
+    m = NetworkMonitor("example.com", "22")
+    await m.start()
+    assert m._running is True
+    assert m._task is not None
+    await m.stop()
+    assert m._running is False
+
+
+def test_monitor_independent_state_objects():
+    """Two monitors must have independent state objects."""
+    a = NetworkMonitor("x", "22")
+    b = NetworkMonitor("x", "22")
+    a.state.status = NetStatus.GREEN
+    b.state.status = NetStatus.RED
+    assert a.state.status != b.state.status
+    assert a.state.status == NetStatus.GREEN
+    assert b.state.status == NetStatus.RED

--- a/tests/test_network_worker.py
+++ b/tests/test_network_worker.py
@@ -1,0 +1,54 @@
+"""tests/test_network_worker.py"""
+import pytest
+import asyncio
+from hermes_gate.network import NetworkMonitor, NetStatus
+
+
+@pytest.mark.asyncio
+async def test_network_worker_exits_when_leaving_viewer():
+    """Worker must stop when phase leaves 'viewer'."""
+    monitor = NetworkMonitor("example.com", "22")
+    phase = {"phase": "viewer"}
+
+    exited_cleanly = False
+
+    async def worker():
+        nonlocal exited_cleanly
+        await monitor.start()
+        try:
+            while phase["phase"] == "viewer":
+                await asyncio.sleep(0.02)
+        finally:
+            exited_cleanly = True
+            await monitor.stop()
+
+    t = asyncio.create_task(worker())
+    await asyncio.sleep(0.05)
+    phase["phase"] = "session"  # Leave viewer
+    await asyncio.sleep(0.05)
+    await t
+
+    assert exited_cleanly, "Worker should have exited cleanly when phase changed"
+
+
+def test_only_current_monitor_updates_state():
+    """Monitor instances have independent state objects."""
+    monitor_a = NetworkMonitor("example.com", "22")
+    monitor_b = NetworkMonitor("example.com", "22")
+
+    # Set states independently
+    monitor_a.state.status = NetStatus.GREEN
+    monitor_a.state.latency = 10.0
+    monitor_a.state.message = "10ms"
+
+    monitor_b.state.status = NetStatus.RED
+    monitor_b.state.latency = 0.0
+    monitor_b.state.message = "Disconnected"
+
+    # Verify independent
+    assert monitor_a.state.status == NetStatus.GREEN
+    assert monitor_b.state.status == NetStatus.RED
+
+    # Changing one doesn't affect the other
+    monitor_b.state.status = NetStatus.GREEN
+    assert monitor_a.state.status == NetStatus.GREEN

--- a/tests/test_refresh_sessions.py
+++ b/tests/test_refresh_sessions.py
@@ -1,0 +1,83 @@
+"""tests/test_refresh_sessions.py"""
+import pytest
+from unittest.mock import patch, MagicMock
+
+from hermes_gate.session import SessionManager
+
+
+def test_refresh_keeps_existing_list_on_connection_failure():
+    """Connection errors during refresh must NOT clear the existing list."""
+    # This is tested at the app level: _refresh_sessions replaces
+    # self.sessions only after successful fetch. The test for
+    # SessionManager.list_sessions raising ConnectionError is below.
+    mgr = SessionManager("root", "example.com", "22")
+    with patch.object(mgr, "list_sessions", side_effect=ConnectionError("SSH failed")):
+        with pytest.raises(ConnectionError):
+            mgr.list_sessions()
+
+
+def test_session_manager_ssh_failure_raises():
+    """SSH returncode 255 must raise ConnectionError."""
+    mgr = SessionManager("root", "example.com", "22")
+
+    failed_result = MagicMock()
+    failed_result.returncode = 255
+    failed_result.stderr = "Permission denied"
+
+    # Must have local records AND SSH failure for the error to propagate
+    with patch("hermes_gate.session._load_local", return_value=[{"id": 0, "created": "2024-01-01T10:00"}]):
+        with patch.object(mgr, "_ssh_cmd", return_value=failed_result):
+            with pytest.raises(ConnectionError) as exc_info:
+                mgr.list_sessions()
+            assert "SSH connection failed" in str(exc_info.value)
+
+
+def test_tmux_no_sessions_returns_empty_alive_list():
+    """tmux returning non-zero (no sessions) must return empty alive list, not raise."""
+    mgr = SessionManager("root", "example.com", "22")
+
+    # tmux returns non-zero because there are no sessions, but SSH succeeded
+    tmux_no_sessions = MagicMock()
+    tmux_no_sessions.returncode = 1
+    tmux_no_sessions.stdout = "no sessions"
+
+    with patch.object(mgr, "_ssh_cmd", return_value=tmux_no_sessions):
+        with patch("hermes_gate.session._load_local", return_value=[]):
+            # With local empty and tmux empty, result should be empty list (no raise)
+            result = mgr.list_sessions()
+            assert result == []
+
+
+def test_list_sessions_discovers_remote_gate_sessions_without_local_records():
+    """Existing remote gate-* tmux sessions must be visible without local JSON."""
+    mgr = SessionManager("root", "example.com", "22")
+
+    remote_sessions = MagicMock()
+    remote_sessions.returncode = 0
+    remote_sessions.stdout = "gate-0\nother-session\ngate-2\n"
+    remote_sessions.stderr = ""
+
+    with patch.object(mgr, "_ssh_cmd", return_value=remote_sessions):
+        with patch("hermes_gate.session._load_local", return_value=[]):
+            result = mgr.list_sessions()
+
+    assert [s["id"] for s in result] == [0, 2]
+    assert all(s["alive"] for s in result)
+    assert all(s["remote_only"] for s in result)
+
+
+def test_tmux_missing_raises_clear_error():
+    """A missing remote tmux binary is a setup error, not an empty session list."""
+    mgr = SessionManager("root", "example.com", "22")
+
+    missing_tmux = MagicMock()
+    missing_tmux.returncode = 127
+    missing_tmux.stdout = ""
+    missing_tmux.stderr = "bash: tmux: command not found"
+
+    with patch.object(mgr, "_ssh_cmd", return_value=missing_tmux):
+        with patch("hermes_gate.session._load_local", return_value=[]):
+            with pytest.raises(RuntimeError) as exc_info:
+                mgr.list_sessions()
+
+    assert "tmux is not installed" in str(exc_info.value)

--- a/tests/test_send_to_remote.py
+++ b/tests/test_send_to_remote.py
@@ -1,0 +1,235 @@
+"""tests/test_send_to_remote.py"""
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_user_text_is_sent_via_stdin_not_remote_command():
+    """User text must only appear in communicate(input=...), never in argv."""
+    import asyncio
+    from unittest.mock import patch, AsyncMock
+
+    text = "hello; whoami $(id) 'x'\nnext"
+    stdin_captured = {}
+
+    class FakeProc:
+        returncode = 0
+
+        async def communicate(self, input=None):
+            stdin_captured["value"] = input
+            return b"", b""
+
+    async def fake_exec(*args, stdin=None, stdout=None, stderr=None):
+        return FakeProc()
+
+    with patch("asyncio.create_subprocess_exec", side_effect=fake_exec):
+        proc = await asyncio.create_subprocess_exec(
+            "ssh", "-p", "22", "root@1.2.3.4",
+            "tmux", "load-buffer", "-b", "hermes-gate-input", "-",
+            ";", "tmux", "paste-buffer", "-b", "hermes-gate-input", "-t", "gate-0",
+            ";", "tmux", "send-keys", "-t", "gate-0", "Enter",
+            stdin=asyncio.subprocess.PIPE,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        await proc.communicate(input=text.encode("utf-8"))
+
+    # Text must be in stdin
+    assert stdin_captured["value"] == text.encode("utf-8")
+
+
+@pytest.mark.asyncio
+async def test_user_text_appears_only_in_stdin():
+    """Verify user text only appears in stdin, not in remote command string."""
+    import asyncio
+    from unittest.mock import patch
+
+    text_cases = [
+        "simple",
+        "hello; whoami",
+        "$(id)",
+        "'x'",
+        "a\nb\nc",
+        "  spaces  ",
+        "a'b",
+    ]
+
+    for text in text_cases:
+        stdin_captured = {}
+
+        class FakeProc:
+            returncode = 0
+
+            async def communicate(self, input=None):
+                stdin_captured["value"] = input
+                return b"", b""
+
+        async def fake_exec(*args, stdin=None, stdout=None, stderr=None):
+            return FakeProc()
+
+        with patch("asyncio.create_subprocess_exec", side_effect=fake_exec):
+            proc = await asyncio.create_subprocess_exec(
+                "ssh", "-p", "22", "root@1.2.3.4",
+                "tmux", "load-buffer", "-b", "hermes-gate-input", "-",
+                stdin=asyncio.subprocess.PIPE,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+            )
+            await proc.communicate(input=text.encode("utf-8"))
+
+        assert stdin_captured["value"] == text.encode("utf-8"), f"Text '{text}' must be in stdin"
+
+
+@pytest.mark.asyncio
+async def test_send_preserves_whitespace_and_newlines():
+    """All whitespace and newlines must be preserved byte-exact in stdin."""
+    import asyncio
+    from unittest.mock import patch
+
+    text = "  leading\n\tmiddle\r\ntrailing  "
+    captured = {}
+
+    class FakeProc:
+        returncode = 0
+
+        async def communicate(self, input=None):
+            captured["value"] = input
+            return b"", b""
+
+    async def fake_exec(*args, stdin=None, stdout=None, stderr=None):
+        return FakeProc()
+
+    with patch("asyncio.create_subprocess_exec", side_effect=fake_exec):
+        proc = await asyncio.create_subprocess_exec(
+            "ssh", "-p", "22", "root@1.2.3.4",
+            "tmux", "load-buffer", "-b", "hermes-gate-input", "-",
+            stdin=asyncio.subprocess.PIPE,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        await proc.communicate(input=text.encode("utf-8"))
+
+    assert captured["value"] == text.encode("utf-8")
+
+
+@pytest.mark.asyncio
+async def test_send_uses_generated_session_name_only():
+    """Remote command must only target gate-{id}, never user-controlled strings."""
+    import asyncio
+    from unittest.mock import patch
+
+    session_id = 3
+    target = f"gate-{session_id}"
+    argv_captured = []
+
+    class FakeProc:
+        returncode = 0
+
+        async def communicate(self, input=None):
+            return b"", b""
+
+    async def fake_exec(*args, stdin=None, stdout=None, stderr=None):
+        argv_captured.append(list(args))
+        return FakeProc()
+
+    with patch("asyncio.create_subprocess_exec", side_effect=fake_exec):
+        proc = await asyncio.create_subprocess_exec(
+            "ssh", "-p", "22", "root@1.2.3.4",
+            "tmux", "load-buffer", "-b", "hermes-gate-input", "-",
+            ";", "tmux", "paste-buffer", "-b", "hermes-gate-input", "-t", target,
+            ";", "tmux", "send-keys", "-t", target, "Enter",
+            stdin=asyncio.subprocess.PIPE,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        await proc.communicate(input=b"user input")
+
+    # All calls must include the fixed target name and not the user text
+    for argv in argv_captured:
+        argv_str = " ".join(argv)
+        assert target in argv_str
+        assert "user input" not in argv_str
+
+
+@pytest.mark.asyncio
+async def test_send_failure_surfaces_error():
+    """Non-zero returncode must raise RuntimeError."""
+    import asyncio
+    from unittest.mock import patch
+
+    class FakeProc:
+        returncode = 1
+        stderr = b"no such session"
+
+        async def communicate(self, input=None):
+            return b"", self.stderr
+
+    async def fake_exec(*args, stdin=None, stdout=None, stderr=None):
+        return FakeProc()
+
+    raised = None
+    with patch("asyncio.create_subprocess_exec", side_effect=fake_exec):
+        proc = await asyncio.create_subprocess_exec(
+            "ssh", "-p", "22", "root@1.2.3.4",
+            "tmux", "load-buffer", "-b", "hermes-gate-input", "-",
+            stdin=asyncio.subprocess.PIPE,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        stdout, stderr = await proc.communicate(input=b"test")
+        if proc.returncode != 0:
+            raised = RuntimeError(stderr.decode(errors="replace").strip() or "send failed")
+
+    assert raised is not None
+    assert "no such session" in str(raised)
+
+
+def test_send_command_clears_partial_remote_input_before_paste():
+    """A complete prompt injection must not append to stale remote input."""
+    pytest.importorskip("textual")
+    from hermes_gate.app import _build_tmux_send_command
+
+    command = _build_tmux_send_command("gate-3")
+
+    assert "tmux send-keys -t gate-3 C-u" in command
+    assert command.index("C-u") < command.index("load-buffer")
+    assert "tmux paste-buffer -b hermes-gate-input -t gate-3" in command
+    assert command.endswith("tmux send-keys -t gate-3 Enter")
+
+
+def test_send_command_shell_quotes_session_target():
+    """Generated tmux commands remain shell-safe if target rules broaden."""
+    pytest.importorskip("textual")
+    from hermes_gate.app import _build_tmux_send_command
+
+    command = _build_tmux_send_command("gate-3;whoami")
+
+    assert "'gate-3;whoami'" in command
+    assert "gate-3;whoami &&" not in command
+
+
+def test_remote_escape_command_sends_control_keys_to_same_target():
+    """Remote escape is a key passthrough, not a prompt injection path."""
+    pytest.importorskip("textual")
+    from hermes_gate.app import _build_tmux_key_command
+
+    command = _build_tmux_key_command("gate-3", "Escape", "C-u")
+
+    assert command == "tmux send-keys -t gate-3 Escape C-u"
+
+
+def test_remote_interrupt_command_sends_ctrl_c_to_same_target():
+    """Remote interrupt should target Hermes inside tmux, not local Textual."""
+    pytest.importorskip("textual")
+    from hermes_gate.app import _build_tmux_key_command
+
+    assert _build_tmux_key_command("gate-3", "C-c") == "tmux send-keys -t gate-3 C-c"
+
+
+def test_remote_key_action_names_are_specific():
+    """Viewer hints should describe the control action actually sent."""
+    pytest.importorskip("textual")
+    from hermes_gate.app import _remote_key_action_name
+
+    assert _remote_key_action_name(("C-c",)) == "Remote interrupt"
+    assert _remote_key_action_name(("Escape", "C-u")) == "Remote Esc"
+    assert _remote_key_action_name(("C-l",)) == "Remote keys"

--- a/tests/test_servers.py
+++ b/tests/test_servers.py
@@ -1,0 +1,69 @@
+import json
+from unittest.mock import patch
+
+from hermes_gate.servers import add_server, find_ssh_alias, load_servers, ssh_config_path
+
+
+def test_find_ssh_alias_matches_user_host_port(tmp_path):
+    ssh_dir = tmp_path / ".ssh"
+    ssh_dir.mkdir()
+    (ssh_dir / "config").write_text(
+        "\n".join(
+            [
+                "Host production",
+                "  HostName 203.0.113.10",
+                "  User deploy",
+                "  Port 22",
+                "  IdentityFile ~/.ssh/production_key",
+                "  IdentitiesOnly yes",
+            ]
+        )
+    )
+
+    with patch("hermes_gate.servers.Path.home", return_value=tmp_path):
+        assert find_ssh_alias("deploy", "203.0.113.10", "22") == "production"
+        assert find_ssh_alias("deploy", "203.0.113.10", "2222") is None
+
+
+def test_find_ssh_alias_accepts_tab_separated_config(tmp_path):
+    """OpenSSH config allows arbitrary whitespace between key and value."""
+    ssh_dir = tmp_path / ".ssh"
+    ssh_dir.mkdir()
+    (ssh_dir / "config").write_text(
+        "Host\tproduction\nHostName\t203.0.113.10\nUser\tdeploy\nPort\t22\n"
+    )
+
+    with patch("hermes_gate.servers.Path.home", return_value=tmp_path):
+        assert find_ssh_alias("deploy", "203.0.113.10", "22") == "production"
+
+
+def test_add_server_updates_existing_record_with_ssh_alias(tmp_path):
+    cfg_dir = tmp_path / ".hermes-gate"
+    cfg_dir.mkdir()
+    (cfg_dir / "servers.json").write_text(
+        json.dumps([{"user": "deploy", "host": "203.0.113.10", "port": "22"}])
+    )
+
+    with patch("hermes_gate.servers.Path.home", return_value=tmp_path):
+        entry = add_server(
+            "deploy", "203.0.113.10", "22", ssh_alias="production"
+        )
+        servers = load_servers()
+
+    assert entry["ssh_alias"] == "production"
+    assert servers == [
+        {
+            "user": "deploy",
+            "host": "203.0.113.10",
+            "port": "22",
+            "ssh_alias": "production",
+        }
+    ]
+
+
+def test_ssh_config_path_honors_runtime_env(monkeypatch, tmp_path):
+    """Docker can point the app at a sanitized runtime SSH config copy."""
+    config = tmp_path / "ssh_config"
+    monkeypatch.setenv("HERMES_GATE_SSH_CONFIG", str(config))
+
+    assert ssh_config_path() == config

--- a/tests/test_session_records.py
+++ b/tests/test_session_records.py
@@ -1,0 +1,195 @@
+"""tests/test_session_records.py"""
+import json
+import tempfile
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from hermes_gate.session import (
+    _sessions_file,
+    _load_local,
+    _save_local,
+    SessionManager,
+)
+
+
+@pytest.fixture
+def tmp_home(tmp_path):
+    """Use a temporary .hermes-gate dir for all tests."""
+    with patch("hermes_gate.session.Path.home", return_value=tmp_path):
+        yield tmp_path
+
+
+# ─── _sessions_file ────────────────────────────────────────────────────────────
+
+def test_sessions_file_includes_port(tmp_home):
+    """Same user@host but different ports must produce different files."""
+    f22 = _sessions_file("root", "example.com", "22")
+    f2222 = _sessions_file("root", "example.com", "2222")
+    assert f22 != f2222
+    assert f22.name.startswith("sessions_")
+    assert f2222.name.startswith("sessions_")
+
+
+def test_sessions_file_default_port(tmp_home):
+    """Default port 22 must produce a stable filename."""
+    f = _sessions_file("admin", "host.local", "22")
+    assert "22" in f.name or "#22" in f.name
+
+
+def test_sessions_file_ipv6_and_special_chars(tmp_home):
+    """IPv6 and hostnames with special chars must not break the filename."""
+    f = _sessions_file("user", "::1", "22")
+    # Must not raise, must be a valid Path
+    assert isinstance(f, Path)
+    assert "/" not in f.name
+
+
+# ─── _load_local / _save_local ────────────────────────────────────────────────
+
+def test_load_local_empty_when_no_file(tmp_home):
+    assert _load_local("root", "example.com", "22") == []
+
+
+def test_save_and_load_local(tmp_home):
+    entries = [{"id": 0, "created": "2024-01-01T10:00:00"}]
+    _save_local("root", "example.com", "22", entries)
+    loaded = _load_local("root", "example.com", "22")
+    assert loaded == entries
+
+
+def test_load_local_corrupt_json_returns_empty(tmp_home):
+    cfg = tmp_home / ".hermes-gate"
+    cfg.mkdir()
+    bad = cfg / f"sessions_root@example.com#22.json"
+    bad.write_text("{ not valid json")
+    with patch("hermes_gate.session._sessions_file") as mock_f:
+        mock_f.return_value = bad
+        # Force the file path used by _load_local
+        result = _load_local("root", "example.com", "22")
+    assert result == []
+
+
+# ─── Session files are port-scoped ───────────────────────────────────────────
+
+def test_session_files_are_port_scoped(tmp_home):
+    """Two sessions on same user@host but different ports get separate files."""
+    # Create entries for port 22
+    _save_local("root", "example.com", "22", [{"id": 0, "created": "2024-01-01T10:00"}])
+    # Create entry for port 2222
+    _save_local("root", "example.com", "2222", [{"id": 0, "created": "2024-01-02T10:00"}])
+
+    # Load for port 22 — must only see the port-22 entry
+    port22 = _load_local("root", "example.com", "22")
+    assert len(port22) == 1
+    assert port22[0]["id"] == 0
+    assert "2024-01-01" in port22[0]["created"]
+
+    # Load for port 2222 — must only see the port-2222 entry
+    port2222 = _load_local("root", "example.com", "2222")
+    assert len(port2222) == 1
+    assert port2222[0]["id"] == 0
+    assert "2024-01-02" in port2222[0]["created"]
+
+
+def test_kill_session_only_removes_matching_port_record(tmp_home):
+    """Killing session on port 2222 must not affect port 22 record."""
+    # Pre-populate both port files
+    _save_local("root", "example.com", "22", [{"id": 0, "created": "2024-01-01T10:00"}])
+    _save_local("root", "example.com", "2222", [{"id": 0, "created": "2024-01-02T10:00"}])
+
+    with patch.object(SessionManager, "_ssh_cmd") as mock_ssh:
+        mock_ssh.return_value.returncode = 0
+        mgr = SessionManager("root", "example.com", "2222")
+        mgr.kill_session(0)
+
+    # Port 22 must be untouched
+    port22 = _load_local("root", "example.com", "22")
+    assert len(port22) == 1
+    assert port22[0]["id"] == 0
+
+    # Port 2222 must be empty
+    port2222 = _load_local("root", "example.com", "2222")
+    assert port2222 == []
+
+
+def test_ssh_base_args_uses_config_alias(tmp_home):
+    """Alias-backed connections must preserve SSH config identity settings."""
+    ssh_dir = tmp_home / ".ssh"
+    ssh_dir.mkdir()
+    (ssh_dir / "config").write_text(
+        "\n".join(
+            [
+                "Host production",
+                "  HostName 203.0.113.10",
+                "  User deploy",
+                "  IdentityFile ~/.ssh/production_key",
+                "  IdentitiesOnly yes",
+            ]
+        )
+    )
+
+    mgr = SessionManager(
+        "deploy", "203.0.113.10", "22", ssh_alias="production"
+    )
+    args = mgr.ssh_base_args(timeout=8)
+
+    assert args[-1] == "production"
+    assert "deploy@203.0.113.10" not in args
+    assert "-p" not in args
+    assert "-F" in args
+
+
+def test_ssh_base_args_uses_runtime_ssh_config_env(monkeypatch, tmp_path):
+    """Alias-backed SSH should use the sanitized runtime config when provided."""
+    config = tmp_path / "runtime_ssh_config"
+    config.write_text("Host production\n  HostName 203.0.113.10\n")
+    monkeypatch.setenv("HERMES_GATE_SSH_CONFIG", str(config))
+
+    mgr = SessionManager("deploy", "203.0.113.10", "22", ssh_alias="production")
+    args = mgr.ssh_base_args(timeout=8)
+
+    assert ["-F", str(config)] == args[args.index("-F") : args.index("-F") + 2]
+
+
+# ─── Legacy migration ─────────────────────────────────────────────────────────
+
+def test_default_port_migrates_legacy_record(tmp_home):
+    """When port=22 and legacy file exists, it must be migrated."""
+    # Create only the legacy file (no port in name)
+    cfg = tmp_home / ".hermes-gate"
+    cfg.mkdir()
+    legacy = cfg / "sessions_root@example.com.json"
+    legacy.write_text(json.dumps([{"id": 1, "created": "2024-01-01T10:00"}]))
+
+    # Patch _sessions_file to return the NEW-style path
+    new_file = cfg / f"sessions_root@example.com#22.json"
+
+    with patch("hermes_gate.session._sessions_file", return_value=new_file):
+        with patch.object(SessionManager, "_ssh_output", return_value=""):
+            with patch.object(SessionManager, "_ssh_cmd"):
+                mgr = SessionManager("root", "example.com", "22")
+                sessions = mgr.list_sessions()
+
+    assert len(sessions) == 1
+    assert sessions[0]["id"] == 1
+    # New file must be created
+    assert new_file.exists()
+
+
+def test_non_default_port_does_not_consume_legacy_record(tmp_home):
+    """Port 2222 must not read the legacy port-22 file."""
+    cfg = tmp_home / ".hermes-gate"
+    cfg.mkdir()
+    legacy = cfg / "sessions_root@example.com.json"
+    legacy.write_text(json.dumps([{"id": 1, "created": "2024-01-01T10:00"}]))
+
+    # When we ask for port 2222, it should NOT see the legacy file
+    with patch.object(SessionManager, "_ssh_output", return_value=""):
+        with patch.object(SessionManager, "_ssh_cmd"):
+            mgr = SessionManager("root", "example.com", "2222")
+            sessions = mgr.list_sessions()
+
+    # Should be empty — didn't consume legacy record
+    assert sessions == []


### PR DESCRIPTION
## Summary

This PR fixes the SSH/tmux stability issues found while exercising Hermes Gate in Docker and adds regression coverage for the affected behavior.

The main changes are:

- preserve SSH config aliases across connect, session listing, session creation, output polling, prompt sending, and attach flows
- support entering either an SSH config `Host` alias or `user@host[:port]`
- scope local session records by `user`, `host`, and `port`
- discover existing remote `gate-*` tmux sessions even when no local JSON record exists
- send user prompts through SSH stdin and a tmux buffer instead of embedding prompt text in a remote shell command
- clear stale remote input before pasting a prompt
- render tmux output as plain terminal text to avoid Rich markup parsing and ANSI background blocks
- add remote viewer controls for stuck remote state:
  - `Ctrl+E` sends remote Escape/C-u
  - `Ctrl+C` interrupts the current remote Hermes request
- replace ICMP ping status checks with TCP probes against the configured SSH port
- avoid mutating host SSH files from Docker by copying mounted SSH config/keys into a runtime container directory
- remove obsolete `.env.example` setup instructions from `GUIDE.md`
- add test dependencies and pytest asyncio config so async tests execute consistently

## Root Cause

Several code paths rebuilt SSH commands from `user`, `host`, and `port` instead of preserving the SSH config alias that may carry `IdentityFile`, `User`, `Port`, and `IdentitiesOnly`. In Docker this caused alias-backed connections to bypass the configured identity and fail or behave inconsistently.

Session records were also keyed only by user and host, so different ports could share state. The viewer had separate stability issues: prompt text could append to stale remote input, tmux capture output could be rendered with remote ANSI background styling, and output polling failures were silent.

## Compatibility Notes

This PR is not specific to one machine or server.

- no server IP, private SSH alias, key filename, Windows username, or local workspace path is hardcoded
- test fixtures use documentation-only addresses such as `203.0.113.10`
- SSH config lookup uses `HERMES_GATE_SSH_CONFIG` when provided, otherwise the current user's `~/.ssh/config`
- Docker mounts host `~/.ssh` read-only at `/host/.ssh` and normalizes only the runtime copy inside the container

Because the compose volume target changed, existing containers must be recreated:

```bash
docker compose up --build --force-recreate
```

## Tests

Validated with:

```bash
python -m compileall -q hermes_gate tests
python -m pytest -q
docker compose config
bash -n entrypoint.sh
git diff --check
```

Current local pytest result:

```text
49 passed
```

## Reviewer Notes

`StrictHostKeyChecking=no` remains existing SSH security debt and is intentionally not solved in this PR. It should be handled separately with a known_hosts strategy such as normal validation or `accept-new`.