### PR TITLE
feat: add confirmed remote session kill flow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,3 +46,20 @@
 
 - Async tests now execute locally after installing `.[test]`; the previous skipped-async-test state is fixed.
 - `StrictHostKeyChecking=no` remains an existing security debt from the current SSH command defaults. It is not a machine-specific change, but it should be addressed separately before treating the tool as hardened.
+
+## 2026-04-17 - Session Kill Flow Improvements
+
+### Fixed
+
+- Changed the session-list destructive shortcut from lowercase `k` to uppercase `K` to match the issue requirement and reduce accidental activation.
+- Added a confirmation modal before killing a session, with `Kill session <name>? [y/N]` semantics and keyboard/button confirm-cancel flows.
+- Updated remote session teardown to detach attached tmux clients before killing the tmux session.
+- Treated missing remote tmux sessions as a non-fatal cleanup case so the local record is still removed and the list can refresh cleanly.
+- Preserved the local record when remote kill fails for real errors, and surfaced a clear error hint in the TUI instead of silently removing the entry.
+- Returned explicit kill result metadata from `SessionManager.kill_session()` so the app can distinguish success, already-missing tmux sessions, and hard failures.
+
+### Tests
+
+- Added TUI tests for uppercase `K`, confirmation gating, confirmed-vs-cancelled behavior, success messaging, and failure messaging.
+- Added session-manager tests for detach-before-kill ordering, missing-tmux cleanup, tmux-missing errors, and local-record preservation on remote kill failure.
+- Validation run: `. .venv/bin/activate && pytest -q` (`50 passed`).

--- a/hermes_gate/app.py
+++ b/hermes_gate/app.py
@@ -105,6 +105,53 @@ class ConnectingScreen(ModalScreen):
             pass
 
 
+class ConfirmKillScreen(ModalScreen[bool]):
+    CSS = """
+    ConfirmKillScreen { align: center middle; }
+    #kill-dialog {
+        width: 60; height: auto;
+        border: thick $error; background: $surface; padding: 1 2;
+    }
+    #kill-title { text-style: bold; margin-bottom: 1; }
+    #kill-hint { color: $text-muted; margin-top: 1; }
+    #kill-btn-row { layout: horizontal; height: auto; margin-top: 1; }
+    #kill-btn-row Button { margin-right: 1; }
+    """
+    BINDINGS = [
+        Binding("y", "confirm", "Confirm"),
+        Binding("n", "cancel", "Cancel"),
+        Binding("escape", "cancel", "Cancel"),
+        Binding("enter", "confirm", "Confirm"),
+    ]
+
+    def __init__(self, session_name: str):
+        super().__init__()
+        self.session_name = session_name
+
+    def compose(self) -> ComposeResult:
+        with Container(id="kill-dialog"):
+            yield Label(f"Kill session {self.session_name}? [y/N]", id="kill-title")
+            yield Label(
+                "This will detach any attached client, stop the remote Hermes session, and kill the tmux session."
+            )
+            with Horizontal(id="kill-btn-row"):
+                yield Button("Kill", variant="error", id="btn-confirm-kill")
+                yield Button("Cancel", variant="default", id="btn-cancel-kill")
+            yield Label("Enter/Y confirm · N/Esc cancel", id="kill-hint")
+
+    def on_mount(self) -> None:
+        self.query_one("#btn-cancel-kill", Button).focus()
+
+    def on_button_pressed(self, event: Button.Pressed) -> None:
+        self.dismiss(event.button.id == "btn-confirm-kill")
+
+    def action_confirm(self) -> None:
+        self.dismiss(True)
+
+    def action_cancel(self) -> None:
+        self.dismiss(False)
+
+
 # ─── Main Application ────────────────────────────────────────────
 
 
@@ -145,7 +192,7 @@ class HermesGateApp(App):
     _BIND_SESSION = [
         Binding("ctrl+q", "noop", show=False),
         Binding("n", "new_session", "New"),
-        Binding("k", "kill_session", "Kill"),
+        Binding("K", "kill_session", "Kill"),
         Binding("r", "refresh", "Refresh"),
         Binding("enter", "attach_session", "Attach"),
         Binding("escape", "back", "Back"),
@@ -502,7 +549,14 @@ class HermesGateApp(App):
         if idx is None or idx >= len(self.sessions):
             self._hint("session-hint", "Please select a session first")
             return
-        self._kill(self.sessions[idx]["id"])
+        session = self.sessions[idx]
+        name = session.get("name") or f"gate-{session['id']}"
+
+        def handle(confirm: bool) -> None:
+            if confirm:
+                self._kill(session["id"])
+
+        self.push_screen(ConfirmKillScreen(name), handle)
 
     @work(exit_on_error=False)
     async def _kill(self, sid: int) -> None:
@@ -510,13 +564,20 @@ class HermesGateApp(App):
             return
         name = f"gate-{sid}"
         loop = asyncio.get_event_loop()
-        ok = await loop.run_in_executor(None, self.session_mgr.kill_session, sid)
-        self._hint(
-            "session-hint",
-            f"Killed {name}"
-            if ok
-            else f"{name} no longer exists on remote, record removed",
-        )
+        try:
+            result = await loop.run_in_executor(None, self.session_mgr.kill_session, sid)
+        except Exception as e:
+            self._hint("session-hint", f"Failed to kill {name}: {e}")
+            return
+
+        if result.get("tmux_missing"):
+            self._hint(
+                "session-hint",
+                f"{name} tmux session already missing, local record removed",
+                error=False,
+            )
+        else:
+            self._hint("session-hint", f"Killed {name}", error=False)
         self._refresh_sessions()
 
     # ═══════════════════════════════════════════════════════════════

--- a/hermes_gate/session.py
+++ b/hermes_gate/session.py
@@ -204,19 +204,41 @@ class SessionManager:
         entry["alive"] = True
         return entry
 
-    def kill_session(self, session_id: int) -> bool:
-        """Kill remote session and remove from local records"""
+    @staticmethod
+    def _tmux_session_missing(result: subprocess.CompletedProcess) -> bool:
+        stderr = (result.stderr or "").lower()
+        stdout = (result.stdout or "").lower()
+        text = f"{stdout}\n{stderr}"
+        return "can't find session" in text or "no such session" in text
+
+    def kill_session(self, session_id: int) -> dict:
+        """Detach clients, kill remote tmux session, and remove local record."""
         name = f"gate-{session_id}"
+        detach_result = self._ssh_cmd(
+            self.tmux_command("detach-client", "-s", name, suppress_stderr=True)
+        )
+        if detach_result.returncode == 127:
+            raise RuntimeError(
+                "Failed to kill remote session: tmux is not installed or is not available in the login PATH"
+            )
+
         result = self._ssh_cmd(
             self.tmux_command("kill-session", "-t", name, suppress_stderr=True)
         )
+        if result.returncode == 127:
+            raise RuntimeError(
+                "Failed to kill remote session: tmux is not installed or is not available in the login PATH"
+            )
 
-        # Remove from local regardless of remote success
+        tmux_missing = self._tmux_session_missing(result)
+        if result.returncode != 0 and not tmux_missing:
+            raise RuntimeError(result.stderr.strip() or f"Failed to kill remote session {name}")
+
         local = _load_local(self.user, self.host, self.port)
         local = [s for s in local if s["id"] != session_id]
         _save_local(self.user, self.host, self.port, local)
 
-        return result.returncode == 0
+        return {"removed": True, "tmux_missing": tmux_missing}
 
     def attach_cmd(self, session_id: int) -> list[str]:
         name = f"gate-{session_id}"

--- a/tests/test_kill_session.py
+++ b/tests/test_kill_session.py
@@ -1,0 +1,125 @@
+"""tests/test_kill_session.py"""
+from unittest.mock import MagicMock
+
+import pytest
+
+pytest.importorskip("textual")
+
+from textual.widgets import Label, ListView
+
+from hermes_gate.app import HermesGateApp
+
+
+async def _run_kill(app: HermesGateApp, sid: int) -> None:
+    await HermesGateApp._kill.__wrapped__(app, sid)
+
+
+def test_session_bindings_use_uppercase_k_for_kill():
+    app = HermesGateApp()
+    kill_binding = next(binding for binding in app._BIND_SESSION if binding.action == "kill_session")
+    assert kill_binding.key == "K"
+
+
+def test_action_kill_session_opens_confirmation_dialog_instead_of_killing_immediately():
+    app = HermesGateApp()
+    app._phase = "session"
+    app.sessions = [{"id": 7, "name": "gate-7", "alive": True, "attached": False}]
+
+    list_view = MagicMock(spec=ListView)
+    list_view.index = 0
+    app.query_one = MagicMock(return_value=list_view)
+    app.push_screen = MagicMock()
+    app._kill = MagicMock()
+
+    app.action_kill_session()
+
+    assert app.push_screen.call_count == 1
+    app._kill.assert_not_called()
+
+
+def test_confirmed_kill_calls_worker_with_selected_session_id():
+    app = HermesGateApp()
+    app._phase = "session"
+    app.sessions = [{"id": 3, "name": "gate-3", "alive": True, "attached": False}]
+
+    list_view = MagicMock(spec=ListView)
+    list_view.index = 0
+    app.query_one = MagicMock(return_value=list_view)
+
+    callbacks = []
+
+    def fake_push_screen(_screen, callback):
+        callbacks.append(callback)
+
+    app.push_screen = fake_push_screen
+    app._kill = MagicMock()
+
+    app.action_kill_session()
+    assert len(callbacks) == 1
+
+    callbacks[0](True)
+    app._kill.assert_called_once_with(3)
+
+
+def test_cancelled_kill_does_not_call_worker():
+    app = HermesGateApp()
+    app._phase = "session"
+    app.sessions = [{"id": 4, "name": "gate-4", "alive": True, "attached": False}]
+
+    list_view = MagicMock(spec=ListView)
+    list_view.index = 0
+    app.query_one = MagicMock(return_value=list_view)
+
+    callbacks = []
+    app.push_screen = lambda _screen, callback: callbacks.append(callback)
+    app._kill = MagicMock()
+
+    app.action_kill_session()
+    callbacks[0](False)
+
+    app._kill.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_kill_updates_hint_when_tmux_session_missing_but_local_record_removed():
+    app = HermesGateApp()
+    app.session_mgr = MagicMock()
+    app.session_mgr.kill_session.return_value = {"removed": True, "tmux_missing": True}
+    app._hint = MagicMock()
+    app._refresh_sessions = MagicMock()
+
+    await _run_kill(app, 9)
+
+    app._hint.assert_called_once_with(
+        "session-hint",
+        "gate-9 tmux session already missing, local record removed",
+        error=False,
+    )
+    app._refresh_sessions.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_kill_shows_error_when_remote_cleanup_fails():
+    app = HermesGateApp()
+    app.session_mgr = MagicMock()
+    app.session_mgr.kill_session.side_effect = RuntimeError("permission denied")
+    app._hint = MagicMock()
+    app._refresh_sessions = MagicMock()
+
+    await _run_kill(app, 5)
+
+    app._hint.assert_called_once_with("session-hint", "Failed to kill gate-5: permission denied")
+    app._refresh_sessions.assert_not_called()
+
+
+def test_session_hint_mentions_uppercase_k():
+    app = HermesGateApp()
+    label = Label("initial", id="session-hint")
+    app.query_one = MagicMock(return_value=label)
+    app.set_timer = MagicMock()
+
+    app._hint("session-hint", "Done", error=False)
+
+    reset = app.set_timer.call_args[0][1]
+    reset()
+    assert "K Kill" in str(label.content)

--- a/tests/test_session_kill_remote.py
+++ b/tests/test_session_kill_remote.py
@@ -1,0 +1,70 @@
+"""tests/test_session_kill_remote.py"""
+from unittest.mock import MagicMock, call, patch
+
+from hermes_gate.session import _load_local, _save_local, SessionManager
+
+
+def test_kill_session_detaches_clients_before_killing_tmux_and_removes_record(tmp_path):
+    with patch("hermes_gate.session.Path.home", return_value=tmp_path):
+        _save_local("root", "example.com", "22", [{"id": 2, "created": "2024-01-01T10:00"}])
+        mgr = SessionManager("root", "example.com", "22")
+
+        ok = MagicMock(returncode=0, stdout="", stderr="")
+        with patch.object(mgr, "_ssh_cmd", return_value=ok) as mock_ssh:
+            result = mgr.kill_session(2)
+
+        assert result == {"removed": True, "tmux_missing": False}
+        commands = [args[0][0] for args in mock_ssh.call_args_list]
+        assert "detach-client" in commands[0]
+        assert "kill-session" in commands[1]
+        assert _load_local("root", "example.com", "22") == []
+
+
+def test_kill_session_treats_missing_tmux_session_as_successful_cleanup(tmp_path):
+    with patch("hermes_gate.session.Path.home", return_value=tmp_path):
+        _save_local("root", "example.com", "22", [{"id": 8, "created": "2024-01-01T10:00"}])
+        mgr = SessionManager("root", "example.com", "22")
+
+        detach_missing = MagicMock(returncode=1, stdout="", stderr="can't find session: gate-8")
+        kill_missing = MagicMock(returncode=1, stdout="", stderr="can't find session: gate-8")
+        with patch.object(mgr, "_ssh_cmd", side_effect=[detach_missing, kill_missing]):
+            result = mgr.kill_session(8)
+
+        assert result == {"removed": True, "tmux_missing": True}
+        assert _load_local("root", "example.com", "22") == []
+
+
+def test_kill_session_keeps_local_record_when_tmux_kill_fails_for_other_reason(tmp_path):
+    with patch("hermes_gate.session.Path.home", return_value=tmp_path):
+        record = {"id": 6, "created": "2024-01-01T10:00"}
+        _save_local("root", "example.com", "22", [record])
+        mgr = SessionManager("root", "example.com", "22")
+
+        detach_ok = MagicMock(returncode=0, stdout="", stderr="")
+        kill_failed = MagicMock(returncode=1, stdout="", stderr="permission denied")
+        with patch.object(mgr, "_ssh_cmd", side_effect=[detach_ok, kill_failed]):
+            try:
+                mgr.kill_session(6)
+            except RuntimeError as exc:
+                assert "permission denied" in str(exc)
+            else:
+                raise AssertionError("kill_session should raise on non-missing tmux failure")
+
+        assert _load_local("root", "example.com", "22") == [record]
+
+
+def test_kill_session_raises_clear_error_when_tmux_binary_missing(tmp_path):
+    with patch("hermes_gate.session.Path.home", return_value=tmp_path):
+        _save_local("root", "example.com", "22", [{"id": 1, "created": "2024-01-01T10:00"}])
+        mgr = SessionManager("root", "example.com", "22")
+
+        missing_tmux = MagicMock(returncode=127, stdout="", stderr="tmux: command not found")
+        with patch.object(mgr, "_ssh_cmd", return_value=missing_tmux):
+            try:
+                mgr.kill_session(1)
+            except RuntimeError as exc:
+                assert "tmux is not installed" in str(exc)
+            else:
+                raise AssertionError("kill_session should raise when tmux is missing")
+
+        assert _load_local("root", "example.com", "22") == [{"id": 1, "created": "2024-01-01T10:00"}]


### PR DESCRIPTION
## Summary
- add uppercase `K` confirmation flow before destructive session kill
- detach attached tmux clients before killing the remote gate session
- preserve entries on real kill failures while cleaning up already-missing tmux sessions
- add regression coverage for TUI confirmation and remote kill behavior

## Test Plan
- [x] . .venv/bin/activate && pytest -q
- [x] python -m compileall -q hermes_gate tests

Closes #3