### PR TITLE
fix: unify session hotkeys and ctrl+b back navigation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,4 +66,5 @@
 - Added confirm-screen tests to lock keyboard-only kill confirmation behavior (`y`/`Enter` confirm, `n`/`Esc` cancel) with no redundant buttons.
 - Added local interaction tests to verify uppercase `N` creates sessions and uppercase `K` opens kill flow only in session phase.
 - Added session-hint text regression tests so the footer copy stays aligned with the actual `N/K/R/Esc/Shift+Tab/Q` bindings.
-- Validation run: `. .venv/bin/activate && pytest -q` (`61 passed`).
+- Added kill-confirm title regression coverage so the prompt stays aligned with the actual `y/n` cancel-confirm semantics.
+- Validation run: `. .venv/bin/activate && pytest -q` (`60 passed`).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,4 +64,5 @@
 - Added session-manager tests for detach-before-kill ordering, missing-tmux cleanup, tmux-missing errors, and local-record preservation on remote kill failure.
 - Added binding regression tests to prove session/select shortcuts are installed up front and enabled only in the correct phase.
 - Added confirm-screen tests to lock keyboard-only kill confirmation behavior (`y`/`Enter` confirm, `n`/`Esc` cancel) with no redundant buttons.
-- Validation run: `. .venv/bin/activate && pytest -q` (`59 passed`).
+- Added local interaction tests to verify uppercase `N` creates sessions and uppercase `K` opens kill flow only in session phase.
+- Validation run: `. .venv/bin/activate && pytest -q` (`60 passed`).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,3 +46,20 @@
 
 - Async tests now execute locally after installing `.[test]`; the previous skipped-async-test state is fixed.
 - `StrictHostKeyChecking=no` remains an existing security debt from the current SSH command defaults. It is not a machine-specific change, but it should be addressed separately before treating the tool as hardened.
+
+## 2026-04-17 - Session Kill Flow Improvements
+
+### Fixed
+
+- Changed the session-list destructive shortcut from lowercase `k` to uppercase `K` to match the issue requirement and reduce accidental activation.
+- Added a confirmation modal before killing a session, with `Kill session <name>? [y/N]` semantics and keyboard/button confirm-cancel flows.
+- Updated remote session teardown to detach attached tmux clients before killing the tmux session.
+- Treated missing remote tmux sessions as a non-fatal cleanup case so the local record is still removed and the list can refresh cleanly.
+- Preserved the local record when remote kill fails for real errors, and surfaced a clear error hint in the TUI instead of silently removing the entry.
+- Returned explicit kill result metadata from `SessionManager.kill_session()` so the app can distinguish success, already-missing tmux sessions, and hard failures.
+
+### Tests
+
+- Added TUI tests for uppercase `K`, confirmation gating, confirmed-vs-cancelled behavior, success messaging, and failure messaging.
+- Added session-manager tests for detach-before-kill ordering, missing-tmux cleanup, tmux-missing errors, and local-record preservation on remote kill failure.
+- Validation run: `. .venv/bin/activate && pytest -q` (`50 passed`).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,4 +65,5 @@
 - Added binding regression tests to prove session/select shortcuts are installed up front and enabled only in the correct phase.
 - Added confirm-screen tests to lock keyboard-only kill confirmation behavior (`y`/`Enter` confirm, `n`/`Esc` cancel) with no redundant buttons.
 - Added local interaction tests to verify uppercase `N` creates sessions and uppercase `K` opens kill flow only in session phase.
-- Validation run: `. .venv/bin/activate && pytest -q` (`60 passed`).
+- Added session-hint text regression tests so the footer copy stays aligned with the actual `N/K/R/Esc/Shift+Tab/Q` bindings.
+- Validation run: `. .venv/bin/activate && pytest -q` (`61 passed`).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,4 +62,5 @@
 
 - Added TUI tests for uppercase `K`, confirmation gating, confirmed-vs-cancelled behavior, success messaging, and failure messaging.
 - Added session-manager tests for detach-before-kill ordering, missing-tmux cleanup, tmux-missing errors, and local-record preservation on remote kill failure.
-- Validation run: `. .venv/bin/activate && pytest -q` (`50 passed`).
+- Added binding regression tests to prove session/select shortcuts are installed up front and enabled only in the correct phase.
+- Validation run: `. .venv/bin/activate && pytest -q` (`53 passed`).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,4 +63,5 @@
 - Added TUI tests for uppercase `K`, confirmation gating, confirmed-vs-cancelled behavior, success messaging, and failure messaging.
 - Added session-manager tests for detach-before-kill ordering, missing-tmux cleanup, tmux-missing errors, and local-record preservation on remote kill failure.
 - Added binding regression tests to prove session/select shortcuts are installed up front and enabled only in the correct phase.
-- Validation run: `. .venv/bin/activate && pytest -q` (`53 passed`).
+- Added confirm-screen tests to lock keyboard-only kill confirmation behavior (`y`/`Enter` confirm, `n`/`Esc` cancel) with no redundant buttons.
+- Validation run: `. .venv/bin/activate && pytest -q` (`59 passed`).

--- a/hermes_gate/app.py
+++ b/hermes_gate/app.py
@@ -114,8 +114,6 @@ class ConfirmKillScreen(ModalScreen[bool]):
     }
     #kill-title { text-style: bold; margin-bottom: 1; }
     #kill-hint { color: $text-muted; margin-top: 1; }
-    #kill-btn-row { layout: horizontal; height: auto; margin-top: 1; }
-    #kill-btn-row Button { margin-right: 1; }
     """
     BINDINGS = [
         Binding("y", "confirm", "Confirm"),
@@ -134,16 +132,7 @@ class ConfirmKillScreen(ModalScreen[bool]):
             yield Label(
                 "This will detach any attached client, stop the remote Hermes session, and kill the tmux session."
             )
-            with Horizontal(id="kill-btn-row"):
-                yield Button("Kill", variant="error", id="btn-confirm-kill")
-                yield Button("Cancel", variant="default", id="btn-cancel-kill")
-            yield Label("Enter/Y confirm · N/Esc cancel", id="kill-hint")
-
-    def on_mount(self) -> None:
-        self.query_one("#btn-cancel-kill", Button).focus()
-
-    def on_button_pressed(self, event: Button.Pressed) -> None:
-        self.dismiss(event.button.id == "btn-confirm-kill")
+            yield Label("enter/y kill · n/Esc cancel", id="kill-hint")
 
     def action_confirm(self) -> None:
         self.dismiss(True)

--- a/hermes_gate/app.py
+++ b/hermes_gate/app.py
@@ -181,6 +181,13 @@ class HermesGateApp(App):
     BINDINGS = [
         Binding("ctrl+q", "noop", show=False),
         Binding("q", "quit", "Quit"),
+        Binding("d", "delete_server", "Delete"),
+        Binding("n", "new_session", "New"),
+        Binding("K", "kill_session", "Kill"),
+        Binding("r", "refresh", "Refresh"),
+        Binding("enter", "attach_session", "Attach"),
+        Binding("escape", "back", "Back"),
+        Binding("shift+tab", "back", "Back"),
     ]
     TITLE = "⚡ Hermes Gate"
 
@@ -230,7 +237,6 @@ class HermesGateApp(App):
     def _show_server_select(self) -> None:
         self._phase = "select"
         self._clear()
-        self.BINDINGS = self._BIND_SELECT
 
         servers = load_servers()
         items = [ListItem(Label(f" 🖥️  {display_name(s)}"), name="srv") for s in servers]
@@ -270,6 +276,16 @@ class HermesGateApp(App):
 
     def action_noop(self) -> None:
         pass
+
+    def check_action(self, action: str, parameters: tuple[object, ...]) -> bool | None:
+        session_actions = {"new_session", "kill_session", "refresh", "attach_session", "back"}
+        select_actions = {"delete_server"}
+
+        if action in session_actions:
+            return self._phase == "session"
+        if action in select_actions:
+            return self._phase == "select"
+        return True
 
     def action_delete_server(self) -> None:
         """D key to delete selected server (only removes from servers.json)"""
@@ -452,8 +468,6 @@ class HermesGateApp(App):
         ssh_alias = ssh_alias or find_ssh_alias(user, host, port)
         self.session_mgr = SessionManager(user, host, port, ssh_alias=ssh_alias)
         self.net_monitor = NetworkMonitor(host, port)
-
-        self.BINDINGS = self._BIND_SESSION
 
         server_name = display_name({"user": user, "host": host, "port": port})
         self.mount(

--- a/hermes_gate/app.py
+++ b/hermes_gate/app.py
@@ -178,26 +178,10 @@ class HermesGateApp(App):
         Binding("K", "kill_session", "Kill"),
         Binding("r", "refresh", "Refresh"),
         Binding("enter", "attach_session", "Attach"),
-        Binding("escape", "back", "Back"),
-        Binding("shift+tab", "back", "Back"),
+        Binding("escape", "noop", show=False),
+        Binding("ctrl+b", "back", "Back"),
     ]
     TITLE = "⚡ Hermes Gate"
-
-    _BIND_SELECT = [
-        Binding("ctrl+q", "noop", show=False),
-        Binding("d", "delete_server", "Delete"),
-        Binding("q", "quit", "Quit"),
-    ]
-    _BIND_SESSION = [
-        Binding("ctrl+q", "noop", show=False),
-        Binding("N", "new_session", "New"),
-        Binding("K", "kill_session", "Kill"),
-        Binding("r", "refresh", "Refresh"),
-        Binding("enter", "attach_session", "Attach"),
-        Binding("escape", "back", "Back"),
-        Binding("shift+tab", "back", "Back"),
-        Binding("q", "quit", "Quit"),
-    ]
 
     def __init__(self):
         super().__init__()
@@ -435,7 +419,7 @@ class HermesGateApp(App):
 
             reset_text = {
                 "server-hint": "↑↓ Select · Enter Connect · D Delete · Q Quit",
-                "session-hint": "↑↓ Select · Enter Attach · N New · K Kill · R Refresh · Esc/Shift+Tab Back · Q Quit",
+                "session-hint": "↑↓ Select · Enter Attach · N New · K Kill · R Refresh · Ctrl+B Back · Q Quit",
             }.get(hint_id, "")
 
             def reset_hint() -> None:
@@ -460,7 +444,6 @@ class HermesGateApp(App):
         ssh_alias = ssh_alias or find_ssh_alias(user, host, port)
         self.session_mgr = SessionManager(user, host, port, ssh_alias=ssh_alias)
         self.net_monitor = NetworkMonitor(host, port)
-
         server_name = display_name({"user": user, "host": host, "port": port})
         self.mount(
             Center(
@@ -468,7 +451,7 @@ class HermesGateApp(App):
                     Label(f"⚡ {server_name} — Sessions", id="session-title"),
                     ListView(id="session-list"),
                     Label(
-                        "↑↓ Select · Enter Attach · N New · K Kill · R Refresh · Esc/Shift+Tab Back · Q Quit",
+                        "↑↓ Select · Enter Attach · N New · K Kill · R Refresh · Ctrl+B Back · Q Quit",
                         id="session-hint",
                     ),
                     id="session-box",
@@ -709,14 +692,25 @@ class HermesGateApp(App):
             return
         self._enter_viewer(s["id"])
 
+    def check_action(self, action: str, parameters: tuple[object, ...]) -> bool | None:
+        if action == "delete_server":
+            return self._phase == "select"
+        if action in {"new_session", "kill_session", "refresh", "attach_session", "back"}:
+            return self._phase == "session"
+        return True
+
     def action_back(self) -> None:
-        """Shift+Tab / Esc — Go back to previous level
+        """Ctrl+B — Go back to previous level
 
         session list → server selection
         """
         # Stop network monitor (all back scenarios)
         if self.net_monitor:
-            asyncio.create_task(self.net_monitor.stop())
+            try:
+                loop = asyncio.get_running_loop()
+                loop.create_task(self.net_monitor.stop())
+            except RuntimeError:
+                asyncio.run(self.net_monitor.stop())
             self.net_monitor = None
 
         if self._phase == "session":

--- a/hermes_gate/app.py
+++ b/hermes_gate/app.py
@@ -433,7 +433,7 @@ class HermesGateApp(App):
 
             reset_text = {
                 "server-hint": "↑↓ Select · Enter Connect · D Delete · Q Quit",
-                "session-hint": "↑↓ Select · Enter Attach · N New · K Kill · Shift+Tab Back",
+                "session-hint": "↑↓ Select · Enter Attach · N New · K Kill · R Refresh · Esc/Shift+Tab Back · Q Quit",
             }.get(hint_id, "")
 
             def reset_hint() -> None:
@@ -466,7 +466,7 @@ class HermesGateApp(App):
                     Label(f"⚡ {server_name} — Sessions", id="session-title"),
                     ListView(id="session-list"),
                     Label(
-                        "↑↓ Select · Enter Attach · N New · K Kill · Shift+Tab Back",
+                        "↑↓ Select · Enter Attach · N New · K Kill · R Refresh · Esc/Shift+Tab Back · Q Quit",
                         id="session-hint",
                     ),
                     id="session-box",

--- a/hermes_gate/app.py
+++ b/hermes_gate/app.py
@@ -107,6 +107,7 @@ class ConnectingScreen(ModalScreen):
 
 class ConfirmKillScreen(ModalScreen[bool]):
     HINT_TEXT = "enter/y kill · Esc/n cancel"
+    TITLE_TEMPLATE = "Kill session {session_name}? [y/n]"
     CSS = """
     ConfirmKillScreen { align: center middle; }
     #kill-dialog {
@@ -126,10 +127,11 @@ class ConfirmKillScreen(ModalScreen[bool]):
     def __init__(self, session_name: str):
         super().__init__()
         self.session_name = session_name
+        self.TITLE_TEXT = self.TITLE_TEMPLATE.format(session_name=session_name)
 
     def compose(self) -> ComposeResult:
         with Container(id="kill-dialog"):
-            yield Label(f"Kill session {self.session_name}? [y/N]", id="kill-title")
+            yield Label(self.TITLE_TEXT, id="kill-title")
             yield Label(
                 "This will detach any attached client, stop the remote Hermes session, and kill the tmux session."
             )

--- a/hermes_gate/app.py
+++ b/hermes_gate/app.py
@@ -106,6 +106,7 @@ class ConnectingScreen(ModalScreen):
 
 
 class ConfirmKillScreen(ModalScreen[bool]):
+    HINT_TEXT = "enter/y kill · Esc/n cancel"
     CSS = """
     ConfirmKillScreen { align: center middle; }
     #kill-dialog {
@@ -132,7 +133,7 @@ class ConfirmKillScreen(ModalScreen[bool]):
             yield Label(
                 "This will detach any attached client, stop the remote Hermes session, and kill the tmux session."
             )
-            yield Label("enter/y kill · n/Esc cancel", id="kill-hint")
+            yield Label(self.HINT_TEXT, id="kill-hint")
 
     def action_confirm(self) -> None:
         self.dismiss(True)
@@ -171,7 +172,7 @@ class HermesGateApp(App):
         Binding("ctrl+q", "noop", show=False),
         Binding("q", "quit", "Quit"),
         Binding("d", "delete_server", "Delete"),
-        Binding("n", "new_session", "New"),
+        Binding("N", "new_session", "New"),
         Binding("K", "kill_session", "Kill"),
         Binding("r", "refresh", "Refresh"),
         Binding("enter", "attach_session", "Attach"),
@@ -187,7 +188,7 @@ class HermesGateApp(App):
     ]
     _BIND_SESSION = [
         Binding("ctrl+q", "noop", show=False),
-        Binding("n", "new_session", "New"),
+        Binding("N", "new_session", "New"),
         Binding("K", "kill_session", "Kill"),
         Binding("r", "refresh", "Refresh"),
         Binding("enter", "attach_session", "Attach"),

--- a/hermes_gate/app.py
+++ b/hermes_gate/app.py
@@ -105,6 +105,53 @@ class ConnectingScreen(ModalScreen):
             pass
 
 
+class ConfirmKillScreen(ModalScreen[bool]):
+    CSS = """
+    ConfirmKillScreen { align: center middle; }
+    #kill-dialog {
+        width: 60; height: auto;
+        border: thick $error; background: $surface; padding: 1 2;
+    }
+    #kill-title { text-style: bold; margin-bottom: 1; }
+    #kill-hint { color: $text-muted; margin-top: 1; }
+    #kill-btn-row { layout: horizontal; height: auto; margin-top: 1; }
+    #kill-btn-row Button { margin-right: 1; }
+    """
+    BINDINGS = [
+        Binding("y", "confirm", "Confirm"),
+        Binding("n", "cancel", "Cancel"),
+        Binding("escape", "cancel", "Cancel"),
+        Binding("enter", "confirm", "Confirm"),
+    ]
+
+    def __init__(self, session_name: str):
+        super().__init__()
+        self.session_name = session_name
+
+    def compose(self) -> ComposeResult:
+        with Container(id="kill-dialog"):
+            yield Label(f"Kill session {self.session_name}? [y/N]", id="kill-title")
+            yield Label(
+                "This will detach any attached client, stop the remote Hermes session, and kill the tmux session."
+            )
+            with Horizontal(id="kill-btn-row"):
+                yield Button("Kill", variant="error", id="btn-confirm-kill")
+                yield Button("Cancel", variant="default", id="btn-cancel-kill")
+            yield Label("Enter/Y confirm · N/Esc cancel", id="kill-hint")
+
+    def on_mount(self) -> None:
+        self.query_one("#btn-cancel-kill", Button).focus()
+
+    def on_button_pressed(self, event: Button.Pressed) -> None:
+        self.dismiss(event.button.id == "btn-confirm-kill")
+
+    def action_confirm(self) -> None:
+        self.dismiss(True)
+
+    def action_cancel(self) -> None:
+        self.dismiss(False)
+
+
 # ─── Main Application ────────────────────────────────────────────
 
 
@@ -145,7 +192,7 @@ class HermesGateApp(App):
     _BIND_SESSION = [
         Binding("ctrl+q", "noop", show=False),
         Binding("n", "new_session", "New"),
-        Binding("k", "kill_session", "Kill"),
+        Binding("K", "kill_session", "Kill"),
         Binding("r", "refresh", "Refresh"),
         Binding("enter", "attach_session", "Attach"),
         Binding("escape", "back", "Back"),
@@ -502,7 +549,14 @@ class HermesGateApp(App):
         if idx is None or idx >= len(self.sessions):
             self._hint("session-hint", "Please select a session first")
             return
-        self._kill(self.sessions[idx]["id"])
+        session = self.sessions[idx]
+        name = session.get("name") or f"gate-{session['id']}"
+
+        def handle(confirm: bool) -> None:
+            if confirm:
+                self._kill(session["id"])
+
+        self.push_screen(ConfirmKillScreen(name), handle)
 
     @work(exit_on_error=False)
     async def _kill(self, sid: int) -> None:
@@ -510,13 +564,20 @@ class HermesGateApp(App):
             return
         name = f"gate-{sid}"
         loop = asyncio.get_event_loop()
-        ok = await loop.run_in_executor(None, self.session_mgr.kill_session, sid)
-        self._hint(
-            "session-hint",
-            f"Killed {name}"
-            if ok
-            else f"{name} no longer exists on remote, record removed",
-        )
+        try:
+            result = await loop.run_in_executor(None, self.session_mgr.kill_session, sid)
+        except Exception as e:
+            self._hint("session-hint", f"Failed to kill {name}: {e}")
+            return
+
+        if result.get("tmux_missing"):
+            self._hint(
+                "session-hint",
+                f"{name} tmux session already missing, local record removed",
+                error=False,
+            )
+        else:
+            self._hint("session-hint", f"Killed {name}", error=False)
         self._refresh_sessions()
 
     # ═══════════════════════════════════════════════════════════════

--- a/hermes_gate/session.py
+++ b/hermes_gate/session.py
@@ -204,19 +204,41 @@ class SessionManager:
         entry["alive"] = True
         return entry
 
-    def kill_session(self, session_id: int) -> bool:
-        """Kill remote session and remove from local records"""
+    @staticmethod
+    def _tmux_session_missing(result: subprocess.CompletedProcess) -> bool:
+        stderr = (result.stderr or "").lower()
+        stdout = (result.stdout or "").lower()
+        text = f"{stdout}\n{stderr}"
+        return "can't find session" in text or "no such session" in text
+
+    def kill_session(self, session_id: int) -> dict:
+        """Detach clients, kill remote tmux session, and remove local record."""
         name = f"gate-{session_id}"
+        detach_result = self._ssh_cmd(
+            self.tmux_command("detach-client", "-s", name, suppress_stderr=True)
+        )
+        if detach_result.returncode == 127:
+            raise RuntimeError(
+                "Failed to kill remote session: tmux is not installed or is not available in the login PATH"
+            )
+
         result = self._ssh_cmd(
             self.tmux_command("kill-session", "-t", name, suppress_stderr=True)
         )
+        if result.returncode == 127:
+            raise RuntimeError(
+                "Failed to kill remote session: tmux is not installed or is not available in the login PATH"
+            )
 
-        # Remove from local regardless of remote success
+        tmux_missing = self._tmux_session_missing(result)
+        if result.returncode != 0 and not tmux_missing:
+            raise RuntimeError(result.stderr.strip() or f"Failed to kill remote session {name}")
+
         local = _load_local(self.user, self.host, self.port)
         local = [s for s in local if s["id"] != session_id]
         _save_local(self.user, self.host, self.port, local)
 
-        return result.returncode == 0
+        return {"removed": True, "tmux_missing": tmux_missing}
 
     def attach_cmd(self, session_id: int) -> list[str]:
         name = f"gate-{session_id}"

--- a/tests/test_app_hints.py
+++ b/tests/test_app_hints.py
@@ -25,6 +25,6 @@ def test_hint_reset_clears_inline_color_instead_of_setting_theme_variable():
 
     timers[0]()
 
-    expected = "↑↓ Select · Enter Attach · N New · K Kill · Shift+Tab Back"
+    expected = "↑↓ Select · Enter Attach · N New · K Kill · R Refresh · Esc/Shift+Tab Back · Q Quit"
     assert str(label.content) == expected
     assert not label.styles.has_rule("color")

--- a/tests/test_app_hints.py
+++ b/tests/test_app_hints.py
@@ -4,9 +4,23 @@ import pytest
 
 pytest.importorskip("textual")
 
+from textual.binding import Binding
 from textual.widgets import Label
 
 from hermes_gate.app import HermesGateApp
+
+
+def _binding_keys(bindings) -> set[str]:
+    return {binding.key for binding in bindings}
+
+
+def test_session_bindings_use_ctrl_b_and_drop_shift_tab() -> None:
+    app = HermesGateApp()
+
+    keys = _binding_keys(app.BINDINGS)
+
+    assert "ctrl+b" in keys
+    assert "shift+tab" not in keys
 
 
 def test_hint_reset_clears_inline_color_instead_of_setting_theme_variable():
@@ -25,6 +39,6 @@ def test_hint_reset_clears_inline_color_instead_of_setting_theme_variable():
 
     timers[0]()
 
-    expected = "↑↓ Select · Enter Attach · N New · K Kill · R Refresh · Esc/Shift+Tab Back · Q Quit"
+    expected = "↑↓ Select · Enter Attach · N New · K Kill · R Refresh · Ctrl+B Back · Q Quit"
     assert str(label.content) == expected
     assert not label.styles.has_rule("color")

--- a/tests/test_back_navigation.py
+++ b/tests/test_back_navigation.py
@@ -1,0 +1,83 @@
+import pytest
+
+pytest.importorskip("textual")
+
+from hermes_gate.app import HermesGateApp
+
+
+class _StubMonitor:
+    def __init__(self) -> None:
+        self.stop_called = False
+
+    async def stop(self) -> None:
+        self.stop_called = True
+
+
+def test_action_back_stops_monitor_and_returns_to_server_list() -> None:
+    app = HermesGateApp()
+    transitions: list[str] = []
+
+    def fake_show_server_select() -> None:
+        transitions.append("show_server_select")
+        app._phase = "select"
+
+    app._show_server_select = fake_show_server_select
+    app._phase = "session"
+
+    monitor = _StubMonitor()
+    app.net_monitor = monitor
+
+    app.action_back()
+
+    assert monitor.stop_called is True
+    assert app.net_monitor is None
+    assert app._phase == "select"
+    assert transitions == ["show_server_select"]
+
+
+@pytest.mark.asyncio
+async def test_ctrl_b_triggers_back_in_session_phase() -> None:
+    app = HermesGateApp()
+    app.on_mount = lambda: None
+    events: list[str] = []
+
+    def fake_show_server_select() -> None:
+        events.append("show_server_select")
+        app._phase = "select"
+
+    app._show_server_select = fake_show_server_select
+
+    async with app.run_test() as pilot:
+        events.clear()
+        app._phase = "session"
+        await pilot.pause()
+
+        await pilot.press("ctrl+b")
+        await pilot.pause()
+
+        assert app._phase == "select"
+        assert events == ["show_server_select"]
+
+
+@pytest.mark.asyncio
+async def test_ctrl_b_is_ignored_outside_session_phase() -> None:
+    app = HermesGateApp()
+    app.on_mount = lambda: None
+    events: list[str] = []
+
+    def fake_show_server_select() -> None:
+        events.append("show_server_select")
+        app._phase = "select"
+
+    app._show_server_select = fake_show_server_select
+
+    async with app.run_test() as pilot:
+        events.clear()
+        app._phase = "select"
+        await pilot.pause()
+
+        await pilot.press("ctrl+b")
+        await pilot.pause()
+
+        assert app._phase == "select"
+        assert events == []

--- a/tests/test_binding_runtime_bug.py
+++ b/tests/test_binding_runtime_bug.py
@@ -1,0 +1,35 @@
+from hermes_gate.app import HermesGateApp
+
+
+def test_app_installs_all_phase_bindings_up_front():
+    app = HermesGateApp()
+
+    keymap = getattr(app, "_bindings").key_to_bindings
+
+    assert "n" in keymap
+    assert "K" in keymap
+    assert "d" in keymap
+
+
+def test_check_action_disables_session_actions_outside_session_phase():
+    app = HermesGateApp()
+    app._phase = "select"
+
+    assert app.check_action("new_session", ()) is False
+    assert app.check_action("kill_session", ()) is False
+    assert app.check_action("attach_session", ()) is False
+    assert app.check_action("refresh", ()) is False
+    assert app.check_action("back", ()) is False
+    assert app.check_action("delete_server", ()) is True
+
+
+def test_check_action_enables_session_actions_inside_session_phase():
+    app = HermesGateApp()
+    app._phase = "session"
+
+    assert app.check_action("new_session", ()) is True
+    assert app.check_action("kill_session", ()) is True
+    assert app.check_action("attach_session", ()) is True
+    assert app.check_action("refresh", ()) is True
+    assert app.check_action("back", ()) is True
+    assert app.check_action("delete_server", ()) is False

--- a/tests/test_binding_runtime_bug.py
+++ b/tests/test_binding_runtime_bug.py
@@ -6,7 +6,7 @@ def test_app_installs_all_phase_bindings_up_front():
 
     keymap = getattr(app, "_bindings").key_to_bindings
 
-    assert "n" in keymap
+    assert "N" in keymap
     assert "K" in keymap
     assert "d" in keymap
 

--- a/tests/test_confirm_kill_screen.py
+++ b/tests/test_confirm_kill_screen.py
@@ -2,7 +2,16 @@ import pytest
 
 pytest.importorskip("textual")
 
-from hermes_gate.app import ConfirmKillScreen
+from hermes_gate.app import ConfirmKillScreen, HermesGateApp
+
+
+def test_session_bindings_use_uppercase_n_for_new_session_and_uppercase_k_for_kill():
+    app = HermesGateApp()
+    new_binding = next(binding for binding in app._BIND_SESSION if binding.action == "new_session")
+    kill_binding = next(binding for binding in app._BIND_SESSION if binding.action == "kill_session")
+
+    assert new_binding.key == "N"
+    assert kill_binding.key == "K"
 
 
 def test_confirm_kill_screen_prompt_and_hint_text_match_single_key_logic():
@@ -13,8 +22,8 @@ def test_confirm_kill_screen_prompt_and_hint_text_match_single_key_logic():
     assert screen.BINDINGS[1].key == "n"
     assert screen.BINDINGS[2].key == "escape"
     assert screen.BINDINGS[3].key == "enter"
-
     assert not hasattr(screen, "on_button_pressed")
+    assert screen.HINT_TEXT == "enter/y kill · Esc/n cancel"
 
 
 def test_confirm_kill_screen_accepts_lowercase_n_for_cancel():

--- a/tests/test_confirm_kill_screen.py
+++ b/tests/test_confirm_kill_screen.py
@@ -2,19 +2,10 @@ import pytest
 
 pytest.importorskip("textual")
 
-from hermes_gate.app import ConfirmKillScreen, HermesGateApp
+from hermes_gate.app import ConfirmKillScreen
 
 
-def test_session_bindings_use_uppercase_n_for_new_session_and_uppercase_k_for_kill():
-    app = HermesGateApp()
-    new_binding = next(binding for binding in app._BIND_SESSION if binding.action == "new_session")
-    kill_binding = next(binding for binding in app._BIND_SESSION if binding.action == "kill_session")
-
-    assert new_binding.key == "N"
-    assert kill_binding.key == "K"
-
-
-def test_confirm_kill_screen_prompt_and_hint_text_match_single_key_logic():
+def test_confirm_kill_screen_title_and_hint_text_match_single_key_logic():
     screen = ConfirmKillScreen("gate-7")
 
     assert screen.session_name == "gate-7"
@@ -24,6 +15,7 @@ def test_confirm_kill_screen_prompt_and_hint_text_match_single_key_logic():
     assert screen.BINDINGS[3].key == "enter"
     assert not hasattr(screen, "on_button_pressed")
     assert screen.HINT_TEXT == "enter/y kill · Esc/n cancel"
+    assert screen.TITLE_TEXT == "Kill session gate-7? [y/n]"
 
 
 def test_confirm_kill_screen_accepts_lowercase_n_for_cancel():

--- a/tests/test_confirm_kill_screen.py
+++ b/tests/test_confirm_kill_screen.py
@@ -1,0 +1,37 @@
+import pytest
+
+pytest.importorskip("textual")
+
+from hermes_gate.app import ConfirmKillScreen
+
+
+def test_confirm_kill_screen_prompt_and_hint_text_match_single_key_logic():
+    screen = ConfirmKillScreen("gate-7")
+
+    assert screen.session_name == "gate-7"
+    assert screen.BINDINGS[0].key == "y"
+    assert screen.BINDINGS[1].key == "n"
+    assert screen.BINDINGS[2].key == "escape"
+    assert screen.BINDINGS[3].key == "enter"
+
+    assert not hasattr(screen, "on_button_pressed")
+
+
+def test_confirm_kill_screen_accepts_lowercase_n_for_cancel():
+    screen = ConfirmKillScreen("gate-7")
+    events = []
+    screen.dismiss = lambda value: events.append(value)
+
+    screen.action_cancel()
+
+    assert events == [False]
+
+
+def test_confirm_kill_screen_accepts_enter_for_confirm():
+    screen = ConfirmKillScreen("gate-7")
+    events = []
+    screen.dismiss = lambda value: events.append(value)
+
+    screen.action_confirm()
+
+    assert events == [True]

--- a/tests/test_kill_session.py
+++ b/tests/test_kill_session.py
@@ -16,7 +16,7 @@ async def _run_kill(app: HermesGateApp, sid: int) -> None:
 
 def test_session_bindings_use_uppercase_k_for_kill():
     app = HermesGateApp()
-    kill_binding = next(binding for binding in app._BIND_SESSION if binding.action == "kill_session")
+    kill_binding = next(binding for binding in app.BINDINGS if binding.action == "kill_session")
     assert kill_binding.key == "K"
 
 

--- a/tests/test_kill_session.py
+++ b/tests/test_kill_session.py
@@ -1,0 +1,125 @@
+"""tests/test_kill_session.py"""
+from unittest.mock import MagicMock
+
+import pytest
+
+pytest.importorskip("textual")
+
+from textual.widgets import Label, ListView
+
+from hermes_gate.app import HermesGateApp
+
+
+async def _run_kill(app: HermesGateApp, sid: int) -> None:
+    await HermesGateApp._kill.__wrapped__(app, sid)
+
+
+def test_session_bindings_use_uppercase_k_for_kill():
+    app = HermesGateApp()
+    kill_binding = next(binding for binding in app._BIND_SESSION if binding.action == "kill_session")
+    assert kill_binding.key == "K"
+
+
+def test_action_kill_session_opens_confirmation_dialog_instead_of_killing_immediately():
+    app = HermesGateApp()
+    app._phase = "session"
+    app.sessions = [{"id": 7, "name": "gate-7", "alive": True, "attached": False}]
+
+    list_view = MagicMock(spec=ListView)
+    list_view.index = 0
+    app.query_one = MagicMock(return_value=list_view)
+    app.push_screen = MagicMock()
+    app._kill = MagicMock()
+
+    app.action_kill_session()
+
+    assert app.push_screen.call_count == 1
+    app._kill.assert_not_called()
+
+
+def test_confirmed_kill_calls_worker_with_selected_session_id():
+    app = HermesGateApp()
+    app._phase = "session"
+    app.sessions = [{"id": 3, "name": "gate-3", "alive": True, "attached": False}]
+
+    list_view = MagicMock(spec=ListView)
+    list_view.index = 0
+    app.query_one = MagicMock(return_value=list_view)
+
+    callbacks = []
+
+    def fake_push_screen(_screen, callback):
+        callbacks.append(callback)
+
+    app.push_screen = fake_push_screen
+    app._kill = MagicMock()
+
+    app.action_kill_session()
+    assert len(callbacks) == 1
+
+    callbacks[0](True)
+    app._kill.assert_called_once_with(3)
+
+
+def test_cancelled_kill_does_not_call_worker():
+    app = HermesGateApp()
+    app._phase = "session"
+    app.sessions = [{"id": 4, "name": "gate-4", "alive": True, "attached": False}]
+
+    list_view = MagicMock(spec=ListView)
+    list_view.index = 0
+    app.query_one = MagicMock(return_value=list_view)
+
+    callbacks = []
+    app.push_screen = lambda _screen, callback: callbacks.append(callback)
+    app._kill = MagicMock()
+
+    app.action_kill_session()
+    callbacks[0](False)
+
+    app._kill.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_kill_updates_hint_when_tmux_session_missing_but_local_record_removed():
+    app = HermesGateApp()
+    app.session_mgr = MagicMock()
+    app.session_mgr.kill_session.return_value = {"removed": True, "tmux_missing": True}
+    app._hint = MagicMock()
+    app._refresh_sessions = MagicMock()
+
+    await _run_kill(app, 9)
+
+    app._hint.assert_called_once_with(
+        "session-hint",
+        "gate-9 tmux session already missing, local record removed",
+        error=False,
+    )
+    app._refresh_sessions.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_kill_shows_error_when_remote_cleanup_fails():
+    app = HermesGateApp()
+    app.session_mgr = MagicMock()
+    app.session_mgr.kill_session.side_effect = RuntimeError("permission denied")
+    app._hint = MagicMock()
+    app._refresh_sessions = MagicMock()
+
+    await _run_kill(app, 5)
+
+    app._hint.assert_called_once_with("session-hint", "Failed to kill gate-5: permission denied")
+    app._refresh_sessions.assert_not_called()
+
+
+def test_session_hint_mentions_uppercase_k():
+    app = HermesGateApp()
+    label = Label("initial", id="session-hint")
+    app.query_one = MagicMock(return_value=label)
+    app.set_timer = MagicMock()
+
+    app._hint("session-hint", "Done", error=False)
+
+    reset = app.set_timer.call_args[0][1]
+    reset()
+    assert "K Kill" in str(label.content)

--- a/tests/test_local_hotkey_interaction.py
+++ b/tests/test_local_hotkey_interaction.py
@@ -6,7 +6,7 @@ from hermes_gate.app import HermesGateApp
 
 
 @pytest.mark.asyncio
-async def test_local_interaction_n_key_triggers_new_session_action():
+async def test_local_interaction_uppercase_n_triggers_new_session_action():
     app = HermesGateApp()
     app._show_server_select = lambda: None
     app._phase = "session"
@@ -14,7 +14,7 @@ async def test_local_interaction_n_key_triggers_new_session_action():
     app.action_new_session = lambda: called.append("new")
 
     async with app.run_test() as pilot:
-        await pilot.press("n")
+        await pilot.press("N")
 
     assert called == ["new"]
 
@@ -34,7 +34,7 @@ async def test_local_interaction_uppercase_k_triggers_kill_session_action():
 
 
 @pytest.mark.asyncio
-async def test_local_interaction_n_is_ignored_outside_session_phase():
+async def test_local_interaction_uppercase_n_is_ignored_outside_session_phase():
     app = HermesGateApp()
     app._show_server_select = lambda: None
     app._phase = "select"
@@ -42,6 +42,6 @@ async def test_local_interaction_n_is_ignored_outside_session_phase():
     app.action_new_session = lambda: called.append("new")
 
     async with app.run_test() as pilot:
-        await pilot.press("n")
+        await pilot.press("N")
 
     assert called == []

--- a/tests/test_local_hotkey_interaction.py
+++ b/tests/test_local_hotkey_interaction.py
@@ -1,0 +1,47 @@
+import pytest
+
+pytest.importorskip("textual")
+
+from hermes_gate.app import HermesGateApp
+
+
+@pytest.mark.asyncio
+async def test_local_interaction_n_key_triggers_new_session_action():
+    app = HermesGateApp()
+    app._show_server_select = lambda: None
+    app._phase = "session"
+    called = []
+    app.action_new_session = lambda: called.append("new")
+
+    async with app.run_test() as pilot:
+        await pilot.press("n")
+
+    assert called == ["new"]
+
+
+@pytest.mark.asyncio
+async def test_local_interaction_uppercase_k_triggers_kill_session_action():
+    app = HermesGateApp()
+    app._show_server_select = lambda: None
+    app._phase = "session"
+    called = []
+    app.action_kill_session = lambda: called.append("kill")
+
+    async with app.run_test() as pilot:
+        await pilot.press("K")
+
+    assert called == ["kill"]
+
+
+@pytest.mark.asyncio
+async def test_local_interaction_n_is_ignored_outside_session_phase():
+    app = HermesGateApp()
+    app._show_server_select = lambda: None
+    app._phase = "select"
+    called = []
+    app.action_new_session = lambda: called.append("new")
+
+    async with app.run_test() as pilot:
+        await pilot.press("n")
+
+    assert called == []

--- a/tests/test_session_hint_text.py
+++ b/tests/test_session_hint_text.py
@@ -21,5 +21,5 @@ def test_session_hint_text_lists_all_available_shortcuts():
     reset()
     assert (
         str(label.content)
-        == "↑↓ Select · Enter Attach · N New · K Kill · R Refresh · Esc/Shift+Tab Back · Q Quit"
+        == "↑↓ Select · Enter Attach · N New · K Kill · R Refresh · Ctrl+B Back · Q Quit"
     )

--- a/tests/test_session_hint_text.py
+++ b/tests/test_session_hint_text.py
@@ -1,0 +1,25 @@
+from unittest.mock import MagicMock
+
+import pytest
+
+pytest.importorskip("textual")
+
+from textual.widgets import Label
+
+from hermes_gate.app import HermesGateApp
+
+
+def test_session_hint_text_lists_all_available_shortcuts():
+    app = HermesGateApp()
+    label = Label("initial", id="session-hint")
+    app.query_one = MagicMock(return_value=label)
+    app.set_timer = MagicMock()
+
+    app._hint("session-hint", "Done", error=False)
+
+    reset = app.set_timer.call_args[0][1]
+    reset()
+    assert (
+        str(label.content)
+        == "↑↓ Select · Enter Attach · N New · K Kill · R Refresh · Esc/Shift+Tab Back · Q Quit"
+    )

--- a/tests/test_session_kill_remote.py
+++ b/tests/test_session_kill_remote.py
@@ -1,0 +1,70 @@
+"""tests/test_session_kill_remote.py"""
+from unittest.mock import MagicMock, call, patch
+
+from hermes_gate.session import _load_local, _save_local, SessionManager
+
+
+def test_kill_session_detaches_clients_before_killing_tmux_and_removes_record(tmp_path):
+    with patch("hermes_gate.session.Path.home", return_value=tmp_path):
+        _save_local("root", "example.com", "22", [{"id": 2, "created": "2024-01-01T10:00"}])
+        mgr = SessionManager("root", "example.com", "22")
+
+        ok = MagicMock(returncode=0, stdout="", stderr="")
+        with patch.object(mgr, "_ssh_cmd", return_value=ok) as mock_ssh:
+            result = mgr.kill_session(2)
+
+        assert result == {"removed": True, "tmux_missing": False}
+        commands = [args[0][0] for args in mock_ssh.call_args_list]
+        assert "detach-client" in commands[0]
+        assert "kill-session" in commands[1]
+        assert _load_local("root", "example.com", "22") == []
+
+
+def test_kill_session_treats_missing_tmux_session_as_successful_cleanup(tmp_path):
+    with patch("hermes_gate.session.Path.home", return_value=tmp_path):
+        _save_local("root", "example.com", "22", [{"id": 8, "created": "2024-01-01T10:00"}])
+        mgr = SessionManager("root", "example.com", "22")
+
+        detach_missing = MagicMock(returncode=1, stdout="", stderr="can't find session: gate-8")
+        kill_missing = MagicMock(returncode=1, stdout="", stderr="can't find session: gate-8")
+        with patch.object(mgr, "_ssh_cmd", side_effect=[detach_missing, kill_missing]):
+            result = mgr.kill_session(8)
+
+        assert result == {"removed": True, "tmux_missing": True}
+        assert _load_local("root", "example.com", "22") == []
+
+
+def test_kill_session_keeps_local_record_when_tmux_kill_fails_for_other_reason(tmp_path):
+    with patch("hermes_gate.session.Path.home", return_value=tmp_path):
+        record = {"id": 6, "created": "2024-01-01T10:00"}
+        _save_local("root", "example.com", "22", [record])
+        mgr = SessionManager("root", "example.com", "22")
+
+        detach_ok = MagicMock(returncode=0, stdout="", stderr="")
+        kill_failed = MagicMock(returncode=1, stdout="", stderr="permission denied")
+        with patch.object(mgr, "_ssh_cmd", side_effect=[detach_ok, kill_failed]):
+            try:
+                mgr.kill_session(6)
+            except RuntimeError as exc:
+                assert "permission denied" in str(exc)
+            else:
+                raise AssertionError("kill_session should raise on non-missing tmux failure")
+
+        assert _load_local("root", "example.com", "22") == [record]
+
+
+def test_kill_session_raises_clear_error_when_tmux_binary_missing(tmp_path):
+    with patch("hermes_gate.session.Path.home", return_value=tmp_path):
+        _save_local("root", "example.com", "22", [{"id": 1, "created": "2024-01-01T10:00"}])
+        mgr = SessionManager("root", "example.com", "22")
+
+        missing_tmux = MagicMock(returncode=127, stdout="", stderr="tmux: command not found")
+        with patch.object(mgr, "_ssh_cmd", return_value=missing_tmux):
+            try:
+                mgr.kill_session(1)
+            except RuntimeError as exc:
+                assert "tmux is not installed" in str(exc)
+            else:
+                raise AssertionError("kill_session should raise when tmux is missing")
+
+        assert _load_local("root", "example.com", "22") == [{"id": 1, "created": "2024-01-01T10:00"}]


### PR DESCRIPTION
## Summary

This PR supersedes #6 and rolls the session hotkey / kill-confirmation work together with the follow-up back-navigation cleanup from issue #5.

The main changes are:

- register all hotkeys up front and gate them by UI phase with `check_action()` instead of swapping `self.BINDINGS` at runtime
- keep uppercase `N` for new session and uppercase `K` for kill in the session list
- keep the keyboard-only kill confirmation flow:
  - `Enter` / `y` confirms
  - `Esc` / `n` cancels
- remove `Shift+Tab`-based back navigation and unify back to `Ctrl+B`
- remove `Esc` as a back shortcut in the session list so back behavior is fully consistent with issue #5
- update session footer / reset hint text to match actual behavior:
  - `↑↓ Select · Enter Attach · N New · K Kill · R Refresh · Ctrl+B Back · Q Quit`
- keep the earlier kill-session cleanup behavior and confirmation UI fixes already covered by #6
- add regression coverage for binding registration, hint text, and interactive `Ctrl+B` back behavior

## Root Cause

Textual does not update the active keymap when `self.BINDINGS` is reassigned after app initialization. The earlier implementation changed bindings at runtime, which caused visible mode changes and real key dispatch to drift apart.

Issue #5 then introduced a second layer of overlap in the same area of the app: back navigation still depended on the old shortcut model and outdated footer text. The clean fix is to keep a single binding table, gate actions by phase, and align both behavior and hint copy around `Ctrl+B`.

## Behavioral Changes

- session list:
  - `N` creates a new session
  - `K` opens kill confirmation
  - `Ctrl+B` returns to the server list
- kill confirmation:
  - `Enter` / `y` kills
  - `Esc` / `n` cancels
  - no extra on-screen confirm/cancel buttons
- session footer / reset hint no longer mentions `Shift+Tab`
- back navigation is now consistently documented and implemented as `Ctrl+B`

## Tests

Validated with:

```bash
python -m compileall -q hermes_gate tests
python -m pytest -q
```

Current local pytest result:

```text
64 passed
```
