### PR TITLE
fix: use remote session info in create_session

### DIFF
--- a/hermes_gate/session.py
+++ b/hermes_gate/session.py
@@ -214,7 +214,7 @@ class SessionManager:
         """Create session: find smallest available id → create remote tmux → save local record"""
         local = _load_local(self.user, self.host, self.port)
 
-        remote_names = self._remote_session_names()
+        remote_names = set(self._remote_session_info())
 
         local_ids = {s["id"] for s in local}
         sid = 0

--- a/tests/test_session_records.py
+++ b/tests/test_session_records.py
@@ -150,6 +150,27 @@ def test_ssh_base_args_uses_accept_new_host_key(tmp_home):
     assert "StrictHostKeyChecking=no" not in args
 
 
+def test_create_session_uses_remote_session_info_and_picks_first_free_id(tmp_home):
+    """create_session should use the refactored remote session info helper."""
+    _save_local("root", "example.com", "22", [{"id": 0, "created": "2024-01-01T10:00"}])
+
+    mgr = SessionManager("root", "example.com", "22")
+
+    with patch.object(
+        mgr,
+        "_remote_session_info",
+        return_value={"gate-1": "1700000000", "other": "1700000001"},
+    ), patch.object(mgr, "_ssh_cmd") as mock_ssh:
+        mock_ssh.return_value.returncode = 0
+        mock_ssh.return_value.stderr = ""
+        entry = mgr.create_session()
+
+    assert entry["id"] == 2
+    assert entry["name"] == "gate-2"
+    assert entry["alive"] is True
+    assert _load_local("root", "example.com", "22")[-1]["id"] == 2
+
+
 def test_ssh_base_args_uses_runtime_ssh_config_env(monkeypatch, tmp_path):
     """Alias-backed SSH should use the sanitized runtime config when provided."""
     config = tmp_path / "runtime_ssh_config"


### PR DESCRIPTION
## Summary

- fix the `create_session()` regression introduced by the `_remote_session_info()` refactor
- derive remote session names from the new helper instead of calling the removed `_remote_session_names()` method
- add direct regression coverage for the create path

## Root Cause

`SessionManager.create_session()` still referenced `_remote_session_names()` after the session-listing refactor moved the remote session metadata path to `_remote_session_info()`.

That left the core new-session path calling a missing helper and raising:

```text
AttributeError: 'SessionManager' object has no attribute '_remote_session_names'
```

## Changes

- update `hermes_gate/session.py` so `create_session()` uses `set(self._remote_session_info())` to derive the remote session-name set
- add a regression test in `tests/test_session_records.py` to verify:
  - the refactored helper is used
  - the first free `gate-N` id is still chosen correctly
  - the created session record is persisted locally

## Testing

### Automated

- `python -m pytest -q tests/test_session_records.py`
- `python -m pytest -q`
- `python -m compileall -q hermes_gate tests`

### Manual

- not run for this patch; this is a small targeted regression fix on the create path

## Risks / Rollback

- low-risk change: only the remote session-name lookup inside `create_session()` is updated
- rollback is straightforward: revert this commit if needed

## Issue Links

- Closes #23
