### PR TITLE
docs: tighten GUIDE around the current remote contract for humans and agents

### DIFF
--- a/GUIDE.md
+++ b/GUIDE.md
@@ -8,7 +8,7 @@
 ./run.sh
 ```
 
-The first run will automatically build the Docker image and launch the TUI interactive interface. Make sure Docker is running and your SSH key is set up (see Prerequisites below).
+The first run will automatically build the Docker image and launch the TUI interactive interface. Make sure Docker is running and your SSH key is set up (see Prerequisites below). Hermes Gate launches a temporary local client, while the long-lived work remains in the remote tmux / Hermes session.
 
 After entering, select "➕ Add Server..." and input:
 
@@ -23,6 +23,9 @@ username@hostname:port    e.g. root@1.2.3.4:2222
 - Docker installed and running
 - SSH key in local `~/.ssh` directory, added to the target server's `authorized_keys`
 - Remote server has `tmux` and `hermes` installed
+- Remote command execution currently assumes a bash-based login-shell environment
+- `tmux` and `hermes` must be available in the remote login-shell PATH used by SSH
+- First-time SSH trust for a new host is currently handled with `StrictHostKeyChecking=accept-new`
 
 ## Daily Use
 
@@ -31,7 +34,7 @@ username@hostname:port    e.g. root@1.2.3.4:2222
 ./run.sh rebuild      # Force rebuild then start
 ```
 
-The container stops automatically when you exit the TUI.
+The container stops automatically when you exit the TUI. When you attach to a session, Hermes Gate suspends its own TUI and hands control to the native remote tmux / Hermes session until you detach or exit.
 
 ## Hot Reload
 
@@ -56,3 +59,6 @@ docker exec -it hermes-gate bash # Enter container shell
 
 - Make sure you have SSH keys (`id_rsa` or `id_ed25519`) in your local `~/.ssh` directory before starting
 - The container stops automatically when you exit the TUI; just run `./run.sh` again next time
+- Attached interaction is primarily native tmux / Hermes behavior rather than a persistent Gate-controlled viewer layer
+- Current remote session checks and launch flow assume bash-based login-shell behavior on the target host
+- SSH first-connection trust currently uses `accept-new`, while later host-key changes are still rejected by SSH

--- a/GUIDE.md
+++ b/GUIDE.md
@@ -57,7 +57,7 @@ docker exec -it hermes-gate bash # Enter container shell
 
 ## Notes
 
-- Make sure you have SSH keys (`id_rsa` or `id_ed25519`) in your local `~/.ssh` directory before starting
+- Make sure you have SSH keys in your local `~/.ssh` directory before starting (any key type: `id_rsa`, `id_ed25519`, custom `IdentityFile`, or SSH agent)
 - The container stops automatically when you exit the TUI; just run `./run.sh` again next time
 - Attached interaction is primarily native tmux / Hermes behavior rather than a persistent Gate-controlled viewer layer
 - Current remote session checks and launch flow assume bash-based login-shell behavior on the target host


### PR DESCRIPTION
## Summary
- clarify `GUIDE.md` without changing product behavior or touching `README.md`
- preserve the original getting-started structure while documenting the current temporary-local-client lifecycle
- document attached-state behavior as native remote tmux / Hermes interaction
- document current remote shell / PATH assumptions and SSH host-trust behavior
- make the guide more usable for both human readers and AI agents by using stable terminology, explicit assumptions, and clearer behavioral boundaries

## Why
Current `main` already behaves this way, and owner comments clarified the intended product positioning and severity of the related issues. This keeps the original human-facing onboarding flow, while making the shipped behavior easier for future agents to interpret without over-inferring unsupported capabilities.

## Validation
- verified the GUIDE still keeps its original section structure
- checked for the new contract/behavior clarifications with a local assertion script

## Issue links
Refs #20
Refs #21
Refs #13
Refs #22
