### PR TITLE
fix: harden preview parsing against malformed session names

### DIFF
--- a/hermes_gate/session.py
+++ b/hermes_gate/session.py
@@ -221,14 +221,20 @@ class SessionManager:
         previews = {}
         for line in result.stdout.splitlines():
             idx = line.find(":")
-            if idx > 0:
-                name = line[:idx]
-                msg = line[idx + 1:].strip()
-                if name.startswith("gate-"):
-                    sid = int(name[5:])
-                    if msg and len(msg) > 40:
-                        msg = msg[:37] + "..."
-                    previews[sid] = msg
+            if idx <= 0:
+                continue
+
+            name = line[:idx]
+            msg = line[idx + 1:].strip()
+
+            match = _GATE_SESSION_RE.match(name)
+            if not match:
+                continue
+
+            sid = int(match.group(1))
+            if msg and len(msg) > 40:
+                msg = msg[:37] + "..."
+            previews[sid] = msg
         return previews
 
     def create_session(self) -> dict:

--- a/tests/test_refresh_sessions.py
+++ b/tests/test_refresh_sessions.py
@@ -81,3 +81,40 @@ def test_tmux_missing_raises_clear_error():
                 mgr.list_sessions()
 
     assert "tmux is not installed" in str(exc_info.value)
+
+
+def test_fetch_previews_skips_non_numeric_gate_names_instead_of_crashing():
+    """Malformed gate-* output lines must be ignored without failing the batch."""
+    mgr = SessionManager("root", "example.com", "22")
+
+    preview_result = MagicMock()
+    preview_result.returncode = 0
+    preview_result.stdout = (
+        "gate-0\tignored because no colon\n"
+        "gate-0:first preview\n"
+        "gate-x:bad name\n"
+        "gate-12:second preview\n"
+        "gate-bak:also bad\n"
+        "junk line\n"
+    )
+    preview_result.stderr = ""
+
+    with patch.object(mgr, "_ssh_cmd", return_value=preview_result):
+        previews = mgr.fetch_previews([0, 12])
+
+    assert previews == {0: "first preview", 12: "second preview"}
+
+
+def test_fetch_previews_preserves_empty_preview_for_valid_session_names():
+    """Valid gate-N names with no extracted message should remain parseable."""
+    mgr = SessionManager("root", "example.com", "22")
+
+    preview_result = MagicMock()
+    preview_result.returncode = 0
+    preview_result.stdout = "gate-0:first\ngate-1:\n"
+    preview_result.stderr = ""
+
+    with patch.object(mgr, "_ssh_cmd", return_value=preview_result):
+        previews = mgr.fetch_previews([0, 1])
+
+    assert previews == {0: "first", 1: ""}


### PR DESCRIPTION
## Summary
- harden `fetch_previews()` to accept only explicit `gate-N` session names
- skip malformed preview lines instead of crashing refresh
- add regression tests for malformed names and empty previews

## Why
The new session-list preview feature should not let malformed shell output break refresh. Hermes Gate currently supports only `gate-N` sessions, so preview parsing should reuse the same explicit validation boundary.

## Test Plan
- `python -m pytest -q tests/test_refresh_sessions.py`
- `python -m pytest -q`
- clean-input validation for valid `gate-N` previews
- malformed-line validation confirms bad names are ignored without crashing
- `python -m pytest -q tests/test_session_records.py tests/test_kill_session.py tests/test_refresh_sessions.py`