### PR TITLE
Merge dev into main

### DIFF
--- a/GUIDE.md
+++ b/GUIDE.md
@@ -8,7 +8,7 @@
 ./run.sh
 ```
 
-The first run will automatically build the Docker image and launch the TUI interactive interface. Make sure Docker is running and your SSH key is set up (see Prerequisites below).
+The first run will automatically build the Docker image and launch the TUI interactive interface. Make sure Docker is running and your SSH key is set up (see Prerequisites below). Hermes Gate launches a temporary local client, while the long-lived work remains in the remote tmux / Hermes session.
 
 After entering, select "➕ Add Server..." and input:
 
@@ -23,6 +23,9 @@ username@hostname:port    e.g. root@1.2.3.4:2222
 - Docker installed and running
 - SSH key in local `~/.ssh` directory, added to the target server's `authorized_keys`
 - Remote server has `tmux` and `hermes` installed
+- Remote command execution currently assumes a bash-based login-shell environment
+- `tmux` and `hermes` must be available in the remote login-shell PATH used by SSH
+- First-time SSH trust for a new host is currently handled with `StrictHostKeyChecking=accept-new`
 
 ## Daily Use
 
@@ -31,7 +34,7 @@ username@hostname:port    e.g. root@1.2.3.4:2222
 ./run.sh rebuild      # Force rebuild then start
 ```
 
-The container stops automatically when you exit the TUI.
+The container stops automatically when you exit the TUI. When you attach to a session, Hermes Gate suspends its own TUI and hands control to the native remote tmux / Hermes session until you detach or exit.
 
 ## Hot Reload
 
@@ -56,3 +59,6 @@ docker exec -it hermes-gate bash # Enter container shell
 
 - Make sure you have SSH keys (`id_rsa` or `id_ed25519`) in your local `~/.ssh` directory before starting
 - The container stops automatically when you exit the TUI; just run `./run.sh` again next time
+- Attached interaction is primarily native tmux / Hermes behavior rather than a persistent Gate-controlled viewer layer
+- Current remote session checks and launch flow assume bash-based login-shell behavior on the target host
+- SSH first-connection trust currently uses `accept-new`, while later host-key changes are still rejected by SSH

--- a/GUIDE.md
+++ b/GUIDE.md
@@ -57,7 +57,7 @@ docker exec -it hermes-gate bash # Enter container shell
 
 ## Notes
 
-- Make sure you have SSH keys (`id_rsa` or `id_ed25519`) in your local `~/.ssh` directory before starting
+- Make sure you have SSH keys in your local `~/.ssh` directory before starting (any key type: `id_rsa`, `id_ed25519`, custom `IdentityFile`, or SSH agent)
 - The container stops automatically when you exit the TUI; just run `./run.sh` again next time
 - Attached interaction is primarily native tmux / Hermes behavior rather than a persistent Gate-controlled viewer layer
 - Current remote session checks and launch flow assume bash-based login-shell behavior on the target host

--- a/hermes_gate/session.py
+++ b/hermes_gate/session.py
@@ -221,14 +221,20 @@ class SessionManager:
         previews = {}
         for line in result.stdout.splitlines():
             idx = line.find(":")
-            if idx > 0:
-                name = line[:idx]
-                msg = line[idx + 1:].strip()
-                if name.startswith("gate-"):
-                    sid = int(name[5:])
-                    if msg and len(msg) > 40:
-                        msg = msg[:37] + "..."
-                    previews[sid] = msg
+            if idx <= 0:
+                continue
+
+            name = line[:idx]
+            msg = line[idx + 1:].strip()
+
+            match = _GATE_SESSION_RE.match(name)
+            if not match:
+                continue
+
+            sid = int(match.group(1))
+            if msg and len(msg) > 40:
+                msg = msg[:37] + "..."
+            previews[sid] = msg
         return previews
 
     def create_session(self) -> dict:

--- a/tests/test_refresh_sessions.py
+++ b/tests/test_refresh_sessions.py
@@ -81,3 +81,40 @@ def test_tmux_missing_raises_clear_error():
                 mgr.list_sessions()
 
     assert "tmux is not installed" in str(exc_info.value)
+
+
+def test_fetch_previews_skips_non_numeric_gate_names_instead_of_crashing():
+    """Malformed gate-* output lines must be ignored without failing the batch."""
+    mgr = SessionManager("root", "example.com", "22")
+
+    preview_result = MagicMock()
+    preview_result.returncode = 0
+    preview_result.stdout = (
+        "gate-0\tignored because no colon\n"
+        "gate-0:first preview\n"
+        "gate-x:bad name\n"
+        "gate-12:second preview\n"
+        "gate-bak:also bad\n"
+        "junk line\n"
+    )
+    preview_result.stderr = ""
+
+    with patch.object(mgr, "_ssh_cmd", return_value=preview_result):
+        previews = mgr.fetch_previews([0, 12])
+
+    assert previews == {0: "first preview", 12: "second preview"}
+
+
+def test_fetch_previews_preserves_empty_preview_for_valid_session_names():
+    """Valid gate-N names with no extracted message should remain parseable."""
+    mgr = SessionManager("root", "example.com", "22")
+
+    preview_result = MagicMock()
+    preview_result.returncode = 0
+    preview_result.stdout = "gate-0:first\ngate-1:\n"
+    preview_result.stderr = ""
+
+    with patch.object(mgr, "_ssh_cmd", return_value=preview_result):
+        previews = mgr.fetch_previews([0, 1])
+
+    assert previews == {0: "first", 1: ""}


### PR DESCRIPTION
## Summary
- Harden `fetch_previews()` to use `_GATE_SESSION_RE` for session name validation (from #26)
- Tighten GUIDE.md with remote contract clarifications (from #25)
- Broaden SSH key type description in GUIDE Notes section
- Add regression tests for malformed preview parsing

## Test plan
- [x] 67 tests pass (`python3 -m pytest tests/ -q`)
- [x] GUIDE.md section structure preserved