### PR TITLE
fix: update Star History embed to /chart endpoint with theme support

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,13 @@ hermes-gate/
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=LehaoLin/hermes-gate&type=Date)](https://star-history.com/#LehaoLin/hermes-gate&Date)
+<a href="https://www.star-history.com/?repos=LehaoLin%2Fhermes-gate&type=date&legend=top-left">
+ <picture>
+   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=LehaoLin/hermes-gate&type=date&theme=dark&legend=top-left" />
+   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=LehaoLin/hermes-gate&type=date&legend=top-left" />
+   <img alt="Star History Chart" src="https://api.star-history.com/chart?repos=LehaoLin/hermes-gate&type=date&legend=top-left" />
+ </picture>
+</a>
 
 ## License
 


### PR DESCRIPTION
## Problem
README Star History chart uses old /svg endpoint which returns empty charts for low-star repos.

## Solution
Switch to /chart endpoint with dark/light theme support as recommended by star-history.com.