### PR TITLE
docs: add Hermes Agent as prerequisite

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Running Hermes Agent on a remote server usually means juggling SSH terminals, wo
 
 ### Prerequisites
 
+- [Hermes Agent](https://github.com/nousresearch/hermes-agent) installed and running on the target server
 - [Docker](https://docs.docker.com/get-docker/)
 - SSH key in `~/.ssh/` added to the target server's `authorized_keys` (any key type: `id_rsa`, `id_ed25519`, custom `IdentityFile`, or SSH agent)
 


### PR DESCRIPTION
目标服务器需要已安装并运行 Hermes Agent，否则 hermes-gate 连上去也没东西用。