### PR TITLE
feat: multi-terminal support — independent TUI sessions in single container

### DIFF
--- a/GUIDE.md
+++ b/GUIDE.md
@@ -32,9 +32,10 @@ username@hostname:port    e.g. root@1.2.3.4:2222
 ```bash
 ./run.sh              # Start and enter container (skips build if already built)
 ./run.sh rebuild      # Force rebuild then start
+./run.sh stop         # Stop and remove the container
 ```
 
-The container stops automatically when you exit the TUI. When you attach to a session, Hermes Gate suspends its own TUI and hands control to the native remote tmux / Hermes session until you detach or exit.
+Multiple terminals can run `./run.sh` simultaneously — each gets an independent TUI session. The container auto-stops when the last session exits.
 
 ## Hot Reload
 

--- a/GUIDE.md
+++ b/GUIDE.md
@@ -8,7 +8,7 @@
 ./run.sh
 ```
 
-The first run will automatically build the Docker image and launch the TUI interactive interface. Make sure Docker is running and your SSH key is set up (see Prerequisites below).
+The first run will automatically build the Docker image and launch the TUI interactive interface. Make sure Docker is running and your SSH key is set up (see Prerequisites below). Hermes Gate launches a temporary local client, while the long-lived work remains in the remote tmux / Hermes session.
 
 After entering, select "➕ Add Server..." and input:
 
@@ -23,6 +23,9 @@ username@hostname:port    e.g. root@1.2.3.4:2222
 - Docker installed and running
 - SSH key in local `~/.ssh` directory, added to the target server's `authorized_keys`
 - Remote server has `tmux` and `hermes` installed
+- Remote command execution currently assumes a bash-based login-shell environment
+- `tmux` and `hermes` must be available in the remote login-shell PATH used by SSH
+- First-time SSH trust for a new host is currently handled with `StrictHostKeyChecking=accept-new`
 
 ## Daily Use
 
@@ -31,7 +34,7 @@ username@hostname:port    e.g. root@1.2.3.4:2222
 ./run.sh rebuild      # Force rebuild then start
 ```
 
-The container stops automatically when you exit the TUI.
+The container stops automatically when you exit the TUI. When you attach to a session, Hermes Gate suspends its own TUI and hands control to the native remote tmux / Hermes session until you detach or exit.
 
 ## Hot Reload
 
@@ -56,3 +59,6 @@ docker exec -it hermes-gate bash # Enter container shell
 
 - Make sure you have SSH keys (`id_rsa` or `id_ed25519`) in your local `~/.ssh` directory before starting
 - The container stops automatically when you exit the TUI; just run `./run.sh` again next time
+- Attached interaction is primarily native tmux / Hermes behavior rather than a persistent Gate-controlled viewer layer
+- Current remote session checks and launch flow assume bash-based login-shell behavior on the target host
+- SSH first-connection trust currently uses `accept-new`, while later host-key changes are still rejected by SSH

--- a/GUIDE.md
+++ b/GUIDE.md
@@ -57,7 +57,7 @@ docker exec -it hermes-gate bash # Enter container shell
 
 ## Notes
 
-- Make sure you have SSH keys (`id_rsa` or `id_ed25519`) in your local `~/.ssh` directory before starting
+- Make sure you have SSH keys in your local `~/.ssh` directory before starting (any key type: `id_rsa`, `id_ed25519`, custom `IdentityFile`, or SSH agent)
 - The container stops automatically when you exit the TUI; just run `./run.sh` again next time
 - Attached interaction is primarily native tmux / Hermes behavior rather than a persistent Gate-controlled viewer layer
 - Current remote session checks and launch flow assume bash-based login-shell behavior on the target host

--- a/README.md
+++ b/README.md
@@ -53,8 +53,11 @@ The first run will automatically build the Docker image and launch the TUI. Make
 ./run.sh              # Start (skips build if already built)
 ./run.sh rebuild      # Force rebuild then start
 ./run.sh update       # git pull + rebuild + start
+./run.sh stop         # Stop and remove the container
 ./run.sh -h           # Show help
 ```
+
+Multiple terminals can run `./run.sh` simultaneously — each gets an independent TUI session. The container auto-stops when the last session exits.
 
 ### TUI Controls
 

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -1,0 +1,138 @@
+# 🏛️ Hermes Gate
+
+一个功能丰富的**终端 TUI**，用于在单个 Docker 容器中远程管理云服务器上的 [Hermes Agent](https://github.com/NousResearch/hermes-agent) tmux 会话。
+
+> *"我喜欢通过 TUI 观察 Hermes Agent 的工作过程——但我的 Agent 跑在远程云服务器上，本地网络又不太稳定。连接断开时，我完全不知道任务还在不在跑。一个被中断的任务意味着数小时的努力白费。当然，我可以用原始的 tmux 来管理——但那不过是一遍又一遍地敲同样的命令。又浪费时间了。"*
+
+> **注意：** Hermes Gate 是 [Hermes Agent](https://github.com/NousResearch/hermes-agent)（[官网](https://hermes-agent.nousresearch.com/)）的配套工具，后者是由 NousResearch 开发的开源 AI Agent 框架。
+
+## 为什么用 Hermes Gate？
+
+> **生命周期说明：** Hermes Gate 是一个**临时本地客户端**。当你退出 TUI 时，Docker 容器会停止。但远程服务器上的 tmux / Hermes Agent 会话**不受影响**——它们会继续运行。只需再次运行 `./run.sh` 即可重新连接。除了本地容器状态外，不会丢失任何东西。
+
+在远程服务器上运行 Hermes Agent 通常意味着需要在多个 SSH 终端之间切换、担心连接断开、以及手动管理 tmux 会话。Hermes Gate 解决了所有这些问题：
+
+- **完整的 TUI 体验** — 浏览服务器、管理会话、查看 Hermes Agent 的实时输出、发送提示词，全部通过基于 [Textual](https://textual.textualize.io/) 的交互式终端界面完成。无需记忆任何 SSH 命令。
+- **网络状态监控** — 基于 TCP 探测的实时延迟监控。连接状态显示在 TUI 中，让你随时知道远程服务器是否可达。注意：如果 SSH 会话断开，需要手动重新进入会话。
+- **通过 tmux 实现会话持久化** — 会话在远程 tmux 中运行，即使你关闭了 Hermes Gate，远程进程也会继续运行。但请注意，退出 TUI 时 Docker 容器会停止——再次运行 `./run.sh` 即可重新连接。
+- **多服务器、多会话** — 在服务器和会话之间即时切换。每个会话独立追踪和管理。
+- **一键启动** — `./run.sh` 自动构建、启动并进入 TUI。需要 Docker 和 `~/.ssh/` 中的 SSH 密钥（见前置要求）。
+
+## 功能特性
+
+- 交互式服务器选择与快速切换
+- 远程 tmux 会话的创建 / 连接 / 销毁
+- 远程 Hermes Agent 实时输出查看与提示词发送
+- 网络状态监控（实时延迟显示和连接状态）
+- 自动主机名解析（通过 `/etc/hosts`）
+- SSH 配置别名支持（使用你的 `~/.ssh/config` 中的主机别名）
+- 远程控制键：`Ctrl+C` 中断、`Ctrl+E` 转义（无需离开 TUI）
+
+## 安装
+
+### 前置要求
+
+- 目标服务器上已安装并运行 [Hermes Agent](https://github.com/nousresearch/hermes-agent)
+- [Docker](https://docs.docker.com/get-docker/)
+- `~/.ssh/` 中的 SSH 密钥已添加到目标服务器的 `authorized_keys`（支持任意密钥类型：`id_rsa`、`id_ed25519`、自定义 `IdentityFile` 或 SSH agent）
+
+### 安装步骤
+
+```bash
+git clone https://github.com/LehaoLin/hermes-gate.git
+cd hermes-gate
+./run.sh
+```
+
+首次运行会自动构建 Docker 镜像并启动 TUI。请确保在启动前 Docker 已运行且 SSH 密钥已配置。
+
+## 使用方法
+
+### 启动
+
+```bash
+./run.sh              # 启动（如已构建则跳过构建）
+./run.sh rebuild      # 强制重新构建后启动
+./run.sh update       # git pull + 重新构建 + 启动
+./run.sh stop         # 停止并移除容器
+./run.sh -h           # 显示帮助
+```
+
+多个终端可以同时运行 `./run.sh`——每个终端获得独立的 TUI 会话。当最后一个会话退出时，容器会自动停止。
+
+### TUI 控制键
+
+| 阶段 | 按键 | 操作 |
+|------|------|------|
+| 服务器选择 | `↑↓` | 切换服务器 |
+| | `Enter` | 连接到选中的服务器 |
+| | `D` | 删除选中的服务器 |
+| | `Q` | 退出 |
+| 会话列表 | `↑↓` | 切换会话 |
+| | `Enter` | 进入会话 |
+| | `N` | 新建会话 |
+| | `K` | 终止会话 |
+| | `R` | 刷新列表 |
+| | `Ctrl+B` | 返回服务器选择 |
+| 查看器 | 在输入框中输入 + `Enter` | 向远程 Hermes Agent 发送提示词 |
+| | `Ctrl+B` | 返回会话列表 |
+
+### 添加服务器
+
+在服务器选择界面选择"➕ Add Server..."。输入格式：
+
+```
+username@ip_address       例：root@1.2.3.4
+username@hostname         例：admin@myserver
+username@hostname:port    例：root@1.2.3.4:2222
+```
+
+默认端口为 22。非标准端口必须显式指定。
+
+## 开发
+
+`hermes_gate/` 目录作为卷挂载到容器中。修改 Python 代码后，**只需重启容器**——无需重新构建。
+
+以下文件修改后需要重新构建（`./run.sh rebuild`）：
+
+- `pyproject.toml` / `requirements.txt`
+- `Dockerfile` / `entrypoint.sh`
+
+### 常用命令
+
+```bash
+docker compose down              # 停止并移除容器
+docker compose logs hermes-gate  # 查看日志
+docker exec -it hermes-gate bash # 进入容器 shell
+```
+
+## 项目结构
+
+```
+hermes-gate/
+├── Dockerfile
+├── docker-compose.yml
+├── entrypoint.sh
+├── run.sh
+├── pyproject.toml
+└── hermes_gate/
+    ├── __main__.py    # 入口
+    ├── app.py         # TUI 主界面
+    ├── servers.py     # 服务器管理与主机名解析
+    ├── session.py     # 远程 tmux 会话管理
+    └── network.py     # 网络状态监控
+```
+
+## Star History
+
+<a href="https://www.star-history.com/?repos=LehaoLin%2Fhermes-gate&type=date&legend=top-left">
+ <picture>
+   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=LehaoLin/hermes-gate&type=date&theme=dark&legend=top-left" />
+   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=LehaoLin/hermes-gate&type=date&legend=top-left" />
+   <img alt="Star History Chart" src="https://api.star-history.com/chart?repos=LehaoLin/hermes-gate&type=date&legend=top-left" />
+ </picture>
+</a>
+
+## 许可证
+
+MIT

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -31,4 +31,4 @@ if [ -f "$RUNTIME_SSH_DIR/config" ]; then
     export HERMES_GATE_SSH_CONFIG="$RUNTIME_SSH_DIR/config"
 fi
 
-exec python -m hermes_gate "$@"
+exec sleep infinity

--- a/hermes_gate/app.py
+++ b/hermes_gate/app.py
@@ -716,11 +716,24 @@ class HermesGateApp(App):
             pass  # Best effort — don't block attach if config fails
 
     def _restore_tmux_after_detach(self, mgr: SessionManager, name: str) -> None:
-        """Restore tmux session options to defaults after detach."""
+        """Restore tmux session options to defaults after detach.
+
+        Skips restore if other clients are still attached to the session.
+        """
         q = shlex.quote
+        # Check if other clients are still attached
+        try:
+            result = subprocess.run(
+                [*mgr.ssh_base_args(timeout=5),
+                 mgr.login_shell_command(f"tmux list-clients -t {q(name)} 2>/dev/null | wc -l")],
+                capture_output=True, text=True, timeout=10,
+            )
+            if result.returncode == 0 and int(result.stdout.strip()) > 0:
+                return
+        except Exception:
+            pass
         commands = " && ".join([
             f"tmux set-option -t {q(name)} prefix C-b",
-            f"tmux unbind-key -T root C-b",
             f"tmux set-option -u -t {q(name)} status-style",
             f"tmux set-option -u -t {q(name)} status-left",
             f"tmux set-option -u -t {q(name)} status-left-length",

--- a/hermes_gate/session.py
+++ b/hermes_gate/session.py
@@ -221,14 +221,20 @@ class SessionManager:
         previews = {}
         for line in result.stdout.splitlines():
             idx = line.find(":")
-            if idx > 0:
-                name = line[:idx]
-                msg = line[idx + 1:].strip()
-                if name.startswith("gate-"):
-                    sid = int(name[5:])
-                    if msg and len(msg) > 40:
-                        msg = msg[:37] + "..."
-                    previews[sid] = msg
+            if idx <= 0:
+                continue
+
+            name = line[:idx]
+            msg = line[idx + 1:].strip()
+
+            match = _GATE_SESSION_RE.match(name)
+            if not match:
+                continue
+
+            sid = int(match.group(1))
+            if msg and len(msg) > 40:
+                msg = msg[:37] + "..."
+            previews[sid] = msg
         return previews
 
     def create_session(self) -> dict:

--- a/hermes_gate/session.py
+++ b/hermes_gate/session.py
@@ -61,7 +61,9 @@ def _load_local(user: str, host: str, port: str = "22") -> list[dict]:
 
 def _save_local(user: str, host: str, port: str, sessions: list[dict]) -> None:
     f = _sessions_file(user, host, port)
-    f.write_text(json.dumps(sessions, indent=2, ensure_ascii=False))
+    tmp = f.with_suffix(".tmp")
+    tmp.write_text(json.dumps(sessions, indent=2, ensure_ascii=False))
+    tmp.replace(f)
 
 
 def _next_id(sessions: list[dict]) -> int:

--- a/run.sh
+++ b/run.sh
@@ -2,16 +2,20 @@
 
 show_help() {
     cat <<'HELP'
-Usage: ./run.sh [OPTION]
+Usage: ./run.sh [COMMAND]
 
 Start the Hermes Gate TUI.
 
-Options:
-      --help, -h     Show this help message and exit
+Commands:
+      (none)         Start (or connect to existing container)
       rebuild        Force rebuild the Docker image, then start
       update         git pull, then rebuild and start
+      stop           Stop and remove the container
+      --help, -h     Show this help message and exit
 
-If no option is given, starts the existing container or builds on first run.
+Multiple terminals can run ./run.sh simultaneously — each gets an
+independent TUI session inside the same container. The container
+auto-stops when the last session exits.
 HELP
 }
 
@@ -24,14 +28,24 @@ set -e
 
 CONTAINER_NAME="hermes-gate"
 
-cleanup() {
-    echo ""
-    echo "Stopping container ${CONTAINER_NAME}..."
-    docker stop "${CONTAINER_NAME}" 2>/dev/null || true
-    echo "Stopped."
+# ─── auto-stop if no other sessions ───────────────────────────────
+_auto_stop() {
+    REMAINING=$(docker exec "${CONTAINER_NAME}" pgrep -c python 2>/dev/null || echo "0")
+    if [ "$REMAINING" -eq 0 ] 2>/dev/null; then
+        echo "No active sessions, stopping container..."
+        docker stop "${CONTAINER_NAME}" 2>/dev/null || true
+    fi
 }
-trap cleanup EXIT INT TERM
 
+# ─── stop subcommand ──────────────────────────────────────────────
+if [ "$1" = "stop" ]; then
+    echo "Stopping ${CONTAINER_NAME}..."
+    docker compose down 2>/dev/null || docker stop "${CONTAINER_NAME}" 2>/dev/null || true
+    echo "Stopped."
+    exit 0
+fi
+
+# ─── rebuild / update ─────────────────────────────────────────────
 FORCE_REBUILD=false
 if [ "$1" = "rebuild" ]; then
     FORCE_REBUILD=true
@@ -45,40 +59,34 @@ if [ "$FORCE_REBUILD" = true ]; then
     echo "Force rebuilding..."
     docker compose down 2>/dev/null || true
     docker compose up -d --build
-    echo "Build complete, attaching..."
-    docker attach "${CONTAINER_NAME}"
+    echo "Build complete, launching TUI..."
+    docker exec -it "${CONTAINER_NAME}" python -m hermes_gate
+    _auto_stop
     exit 0
 fi
 
+# ─── ensure container is running ──────────────────────────────────
 RUNNING=$(docker inspect -f '{{.State.Running}}' "${CONTAINER_NAME}" 2>/dev/null || echo "false")
 
-if [ "$RUNNING" = "true" ]; then
-    echo "Container already running, attaching..."
-    docker attach "${CONTAINER_NAME}"
-    exit 0
+if [ "$RUNNING" != "true" ]; then
+    EXISTS=$(docker inspect -f '{{.Id}}' "${CONTAINER_NAME}" 2>/dev/null || echo "")
+
+    if [ -n "$EXISTS" ]; then
+        echo "Container exists (stopped), starting..."
+        docker start "${CONTAINER_NAME}"
+    else
+        HAS_IMAGE=$(docker images --format "{{.Repository}}:{{.Tag}}" | grep -i "hermes" || true)
+        if [ -n "$HAS_IMAGE" ]; then
+            echo "Image found, starting container..."
+            docker compose up -d
+        else
+            echo "No image found, building for the first time..."
+            docker compose up -d --build
+        fi
+    fi
+    echo "Container started, launching TUI..."
 fi
 
-EXISTS=$(docker inspect -f '{{.Id}}' "${CONTAINER_NAME}" 2>/dev/null || echo "")
-
-if [ -n "$EXISTS" ]; then
-    echo "Container exists (stopped), starting..."
-    docker start "${CONTAINER_NAME}"
-    echo "Started, attaching..."
-    docker attach "${CONTAINER_NAME}"
-    exit 0
-fi
-
-HAS_IMAGE=$(docker images --format "{{.Repository}}:{{.Tag}}" | grep -i "hermes" || true)
-
-if [ -n "$HAS_IMAGE" ]; then
-    echo "Image found, starting container (skip build)..."
-    docker compose up -d
-    echo "Started, attaching..."
-    docker attach "${CONTAINER_NAME}"
-    exit 0
-fi
-
-echo "No image found, building for the first time..."
-docker compose up -d --build
-echo "Build complete, attaching..."
-docker attach "${CONTAINER_NAME}"
+# ─── launch TUI ───────────────────────────────────────────────────
+docker exec -it "${CONTAINER_NAME}" python -m hermes_gate
+_auto_stop

--- a/tests/test_refresh_sessions.py
+++ b/tests/test_refresh_sessions.py
@@ -81,3 +81,40 @@ def test_tmux_missing_raises_clear_error():
                 mgr.list_sessions()
 
     assert "tmux is not installed" in str(exc_info.value)
+
+
+def test_fetch_previews_skips_non_numeric_gate_names_instead_of_crashing():
+    """Malformed gate-* output lines must be ignored without failing the batch."""
+    mgr = SessionManager("root", "example.com", "22")
+
+    preview_result = MagicMock()
+    preview_result.returncode = 0
+    preview_result.stdout = (
+        "gate-0\tignored because no colon\n"
+        "gate-0:first preview\n"
+        "gate-x:bad name\n"
+        "gate-12:second preview\n"
+        "gate-bak:also bad\n"
+        "junk line\n"
+    )
+    preview_result.stderr = ""
+
+    with patch.object(mgr, "_ssh_cmd", return_value=preview_result):
+        previews = mgr.fetch_previews([0, 12])
+
+    assert previews == {0: "first preview", 12: "second preview"}
+
+
+def test_fetch_previews_preserves_empty_preview_for_valid_session_names():
+    """Valid gate-N names with no extracted message should remain parseable."""
+    mgr = SessionManager("root", "example.com", "22")
+
+    preview_result = MagicMock()
+    preview_result.returncode = 0
+    preview_result.stdout = "gate-0:first\ngate-1:\n"
+    preview_result.stderr = ""
+
+    with patch.object(mgr, "_ssh_cmd", return_value=preview_result):
+        previews = mgr.fetch_previews([0, 1])
+
+    assert previews == {0: "first", 1: ""}


### PR DESCRIPTION
## Summary
- Support running multiple `./run.sh` simultaneously — each terminal gets an independent TUI session inside one container
- Container auto-stops when the last TUI session exits
- Add `./run.sh stop` subcommand for explicit shutdown
- Fix Ctrl+B detach bug when multiple users share tmux sessions (remove server-level unbind-key)
- Atomic JSON writes for concurrent session record safety

## Changes
- `entrypoint.sh`: `sleep infinity` instead of `exec python` to keep container alive
- `run.sh`: `docker exec -it` instead of `docker attach`; auto-stop logic; `stop` subcommand
- `app.py`: skip tmux config restore when other clients attached; remove global `unbind-key`
- `session.py`: atomic file writes (tmp + rename)
- `README.md`, `README_ZH.md`, `GUIDE.md`: updated usage docs

## Test plan
- [x] 67 tests pass
- [x] Manual test: two terminals run ./run.sh independently
- [x] Manual test: Ctrl+B works in both terminals
- [x] Manual test: container auto-stops when last session exits