### PR TITLE
fix: align Windows launcher with current runtime model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## 2026-04-19 - Windows launcher parity and PowerShell 5.1 compatibility
+
+### Fixed
+
+- Reworked `run.ps1` to launch Hermes Gate via `docker exec -it ... python -m hermes_gate` instead of `docker attach`, aligning Windows startup with the current `run.sh` / `entrypoint.sh` lifecycle.
+- Added Windows `stop` command support and replaced unconditional container shutdown with idle-only auto-stop behavior so multiple local TUI sessions can coexist without one exit killing the shared container.
+- Regenerate `docker-compose.win.yml` deterministically on each run to avoid silent drift from current compose settings.
+- Added preflight checks for `docker compose`, Docker daemon availability, `git` on `update`, and missing `~/.ssh` warnings.
+- Replaced `Set-Content -Encoding UTF8NoBOM` with .NET UTF-8 no-BOM file writing so the script remains compatible with Windows PowerShell 5.1.
+
+### Tests
+
+- Added `tests/test_run_ps1.py` to lock Windows launcher behavior: `docker exec` launch path, `stop` command support, PowerShell 5.1-safe compose writing, and README command parity.
+- Validation run: `python -m pytest -q tests/test_run_ps1.py` (`4 passed`).
+- Validation run: `python -m pytest -q` (`71 passed`).
+- Validation run: `python -m compileall -q hermes_gate tests`.
+
+# Changelog
+
 ## 2026-04-17 - Compatibility and Stability Fixes
 
 ### Compatibility Review

--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ Multiple terminals can run `./run.sh` simultaneously — each gets an independen
 .\run.ps1              # Start (skips build if already built)
 .\run.ps1 rebuild      # Force rebuild then start
 .\run.ps1 update       # git pull + rebuild + start
+.\run.ps1 stop         # Stop and remove the container
 ```
 
 ### TUI Controls

--- a/run.ps1
+++ b/run.ps1
@@ -7,11 +7,12 @@
     .\run.ps1
     .\run.ps1 rebuild
     .\run.ps1 update
+    .\run.ps1 stop
 #>
 
 param(
     [Parameter(Position = 0)]
-    [ValidateSet("rebuild", "update")]
+    [ValidateSet("rebuild", "update", "stop")]
     [string]$Command
 )
 
@@ -19,14 +20,18 @@ $ErrorActionPreference = "Stop"
 $ContainerName = "hermes-gate"
 $ProjectDir = $PSScriptRoot
 
+function Write-Utf8NoBomFile([string]$Path, [string]$Content) {
+    $utf8NoBom = New-Object System.Text.UTF8Encoding($false)
+    [System.IO.File]::WriteAllText($Path, $Content, $utf8NoBom)
+}
+
 # ---------------------------------------------------------------------------
 # Docker Compose on Windows cannot mount /etc/hosts (Linux/macOS only).
-# We generate a standalone compose file that skips that mount.
+# Generate a Windows-specific compose file deterministically on each run.
 # ---------------------------------------------------------------------------
 function Get-ComposeFile {
     $winCompose = Join-Path $ProjectDir "docker-compose.win.yml"
-    if (-not (Test-Path $winCompose)) {
-        @"
+    $composeContent = @"
 services:
   hermes-gate:
     build: .
@@ -37,26 +42,72 @@ services:
     stdin_open: true
     tty: true
     restart: unless-stopped
-"@ | Set-Content -Path $winCompose -Encoding UTF8NoBOM
-        Write-Host "Created docker-compose.win.yml for Windows."
-    }
+"@
+    Write-Utf8NoBomFile -Path $winCompose -Content $composeContent
     return $winCompose
 }
 
-# ---------------------------------------------------------------------------
-# Attach to container with cleanup on Ctrl+C
-# ---------------------------------------------------------------------------
-function Attach-Container([string]$Name) {
-    Write-Host ""
-    Write-Host "Attaching to $Name... (Press Ctrl+C to detach)"
-    Write-Host ""
-    try {
-        docker attach $Name
-    } finally {
-        Write-Host ""
-        Write-Host "Stopping container $Name..."
+function Assert-Command([string]$Name, [string]$Message) {
+    if (-not (Get-Command $Name -ErrorAction SilentlyContinue)) {
+        Write-Host $Message -ForegroundColor Red
+        exit 1
+    }
+}
+
+function Assert-DockerCompose {
+    docker compose version *> $null
+    if ($LASTEXITCODE -ne 0) {
+        Write-Host "Error: 'docker compose' is not available. Please install/update Docker Desktop." -ForegroundColor Red
+        exit 1
+    }
+}
+
+function Assert-DockerDaemon {
+    docker info *> $null
+    if ($LASTEXITCODE -ne 0) {
+        Write-Host "Error: Docker daemon is not running. Please start Docker Desktop." -ForegroundColor Red
+        exit 1
+    }
+}
+
+function Assert-SshDirectory {
+    $sshDir = Join-Path $HOME ".ssh"
+    if (-not (Test-Path $sshDir)) {
+        Write-Host "Warning: $sshDir was not found. SSH connections may fail until your SSH keys are available." -ForegroundColor Yellow
+    }
+}
+
+function Test-ContainerExists([string]$Name) {
+    docker inspect -f '{{.Id}}' $Name 2>$null | Out-Null
+    return ($LASTEXITCODE -eq 0)
+}
+
+function Invoke-Tui([string]$Name) {
+    docker exec -it $Name python -m hermes_gate
+}
+
+function Stop-IfIdle([string]$Name) {
+    $remaining = docker exec $Name sh -lc "pgrep -fc 'python -m hermes_gate'" 2>$null
+    if ($LASTEXITCODE -ne 0) {
+        $remaining = "0"
+    }
+    $remaining = ($remaining | Out-String).Trim()
+    if (-not $remaining) {
+        $remaining = "0"
+    }
+    if ([int]$remaining -eq 0) {
+        Write-Host "No active sessions, stopping container..."
         docker stop $Name 2>$null | Out-Null
-        Write-Host "Stopped."
+    }
+}
+
+function Launch-Tui([string]$Name) {
+    Write-Host "Launching TUI..."
+    try {
+        Invoke-Tui $Name
+    }
+    finally {
+        Stop-IfIdle $Name
     }
 }
 
@@ -65,13 +116,27 @@ function Attach-Container([string]$Name) {
 # ---------------------------------------------------------------------------
 Set-Location $ProjectDir
 
-if (-not (Get-Command docker -ErrorAction SilentlyContinue)) {
-    Write-Host "Error: Docker not found. Please install Docker Desktop for Windows." -ForegroundColor Red
-    exit 1
+Assert-Command -Name docker -Message "Error: Docker not found. Please install Docker Desktop for Windows."
+Assert-DockerCompose
+Assert-DockerDaemon
+Assert-SshDirectory
+
+if ($Command -eq "update") {
+    Assert-Command -Name git -Message "Error: git not found. Please install Git before using '.\run.ps1 update'."
 }
 
 $ComposeFile = Get-ComposeFile
 $ComposeArgs = @("-f", $ComposeFile)
+
+if ($Command -eq "stop") {
+    Write-Host "Stopping $ContainerName..."
+    docker compose @ComposeArgs down 2>$null
+    if ($LASTEXITCODE -ne 0) {
+        docker stop $ContainerName 2>$null | Out-Null
+    }
+    Write-Host "Stopped."
+    exit 0
+}
 
 # --- update ---
 if ($Command -eq "update") {
@@ -83,28 +148,26 @@ if ($Command -eq "update") {
 # --- rebuild ---
 if ($Command -eq "rebuild") {
     Write-Host "Force rebuilding..."
-    docker compose @ComposeArgs down 2>$null
+    docker compose @ComposeArgs down 2>$null | Out-Null
     docker compose @ComposeArgs up -d --build
-    Write-Host "Build complete, attaching..."
-    Attach-Container $ContainerName
+    Write-Host "Build complete."
+    Launch-Tui $ContainerName
     exit 0
 }
 
 # --- default: smart start ---
-
 $running = docker inspect -f '{{.State.Running}}' $ContainerName 2>$null
 if ($running -eq "true") {
-    Write-Host "Container already running, attaching..."
-    Attach-Container $ContainerName
+    Write-Host "Container already running."
+    Launch-Tui $ContainerName
     exit 0
 }
 
-$exists = docker inspect -f '{{.Id}}' $ContainerName 2>$null
-if ($exists) {
+if (Test-ContainerExists $ContainerName) {
     Write-Host "Container exists (stopped), starting..."
     docker start $ContainerName | Out-Null
-    Write-Host "Started, attaching..."
-    Attach-Container $ContainerName
+    Write-Host "Started."
+    Launch-Tui $ContainerName
     exit 0
 }
 
@@ -112,12 +175,12 @@ $hasImage = docker images --format "{{.Repository}}:{{.Tag}}" | Where-Object { $
 if ($hasImage) {
     Write-Host "Image found, starting container (skip build)..."
     docker compose @ComposeArgs up -d
-    Write-Host "Started, attaching..."
-    Attach-Container $ContainerName
+    Write-Host "Started."
+    Launch-Tui $ContainerName
     exit 0
 }
 
 Write-Host "No image found, building for the first time..."
 docker compose @ComposeArgs up -d --build
-Write-Host "Build complete, attaching..."
-Attach-Container $ContainerName
+Write-Host "Build complete."
+Launch-Tui $ContainerName

--- a/tests/test_run_ps1.py
+++ b/tests/test_run_ps1.py
@@ -1,0 +1,35 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).parent.parent
+
+
+def _run_ps1() -> str:
+    return (ROOT / "run.ps1").read_text(encoding="utf-8")
+
+
+def test_run_ps1_uses_docker_exec_for_tui_launch():
+    """Windows launcher should start Hermes Gate via docker exec, not attach."""
+    content = _run_ps1()
+    assert 'docker exec -it $Name python -m hermes_gate' in content
+    assert 'docker attach $Name' not in content
+
+
+def test_run_ps1_supports_stop_command():
+    """Windows launcher should expose the same explicit stop command as run.sh."""
+    content = _run_ps1()
+    assert '[ValidateSet("rebuild", "update", "stop")]' in content
+    assert 'if ($Command -eq "stop")' in content
+
+
+def test_run_ps1_avoids_utf8nobom_encoding_for_ps51_compatibility():
+    """PowerShell 5.1-compatible compose writing should not rely on UTF8NoBOM."""
+    content = _run_ps1()
+    assert 'UTF8NoBOM' not in content
+    assert 'System.Text.UTF8Encoding($false)' in content
+
+
+def test_readme_documents_windows_stop_command():
+    """README Windows usage should stay aligned with run.ps1 command surface."""
+    readme = (ROOT / "README.md").read_text(encoding="utf-8")
+    assert '.\\run.ps1 stop' in readme


### PR DESCRIPTION
## Summary
- align `run.ps1` with the current `run.sh` / `entrypoint.sh` lifecycle by launching Hermes Gate via `docker exec -it ... python -m hermes_gate`
- add Windows `stop` support, idle-only auto-stop behavior, deterministic compose generation, and clearer preflight checks
- replace `Set-Content -Encoding UTF8NoBOM` with a PowerShell 5.1-safe .NET UTF-8 no-BOM write path and add regression coverage

## Why
`run.ps1` had drifted from the current container model:
- it still used `docker attach` even though the container entrypoint now stays alive with `sleep infinity`
- it stopped the whole container unconditionally on exit, which breaks the multi-session local-client behavior already supported by `run.sh`
- it declared PowerShell 5.1 support while relying on `UTF8NoBOM` in a way that is not a safe 5.1 baseline

This PR brings the Windows launcher back in line with the current temporary-local-client contract.

## Changes
- replace `docker attach` with `docker exec -it ... python -m hermes_gate`
- add `stop` command parity for Windows
- stop the container only when no local TUI sessions remain
- regenerate `docker-compose.win.yml` on each run to avoid stale drift
- add preflight checks for `docker`, `docker compose`, Docker daemon, `git` on `update`, and missing `~/.ssh`
- use `.NET` `UTF8Encoding($false)` for PowerShell 5.1-safe UTF-8 no-BOM file writing
- add `tests/test_run_ps1.py`
- document `.\run.ps1 stop` in `README.md`

## Validation
- `python3 -m pytest -q tests/test_run_ps1.py`
- `python3 -m pytest -q`
- `python3 -m compileall -q hermes_gate tests`
