### PR TITLE
fix: restore mouse-wheel scroll in attach mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## 2026-04-19 - Attach mouse-wheel scroll fix
+
+### Fixed
+
+- Added attach-scoped tmux mouse-wheel bindings so scrolling inside a Hermes session attached via Hermes Gate enters tmux copy-mode / pane scrollback instead of falling through as Hermes history navigation.
+- Restored the attach-time mouse / wheel bindings on detach alongside the existing temporary `Ctrl+B` / status-bar tmux overrides, preserving the current thin-client-style best-effort cleanup model.
+
+### Tests
+
+- Added `tests/test_attach_mouse_scroll.py` to lock attach-time tmux mouse configuration and detach-time cleanup behavior.
+- Validation run: `python -m pytest -q tests/test_attach_mouse_scroll.py` (`2 passed`).
+- Validation run: `python -m pytest -q` (`73 passed`).
+- Validation run: `python -m compileall -q hermes_gate tests`.
+
 ## 2026-04-19 - Windows launcher parity and PowerShell 5.1 compatibility
 
 ### Fixed

--- a/hermes_gate/app.py
+++ b/hermes_gate/app.py
@@ -720,6 +720,12 @@ class HermesGateApp(App):
             f"tmux set-option -t {q(name)} prefix C-a",
             # Bind C-b in root table to detach directly
             f"tmux bind-key -T root C-b detach-client",
+            # Enable mouse support and make wheel scroll pane history when not already handling mouse events.
+            f"tmux set-option -t {q(name)} mouse on",
+            f"tmux bind-key -T root WheelUpPane if-shell -F '#{{mouse_any_flag}}' 'send-keys -M' 'copy-mode -e'",
+            f"tmux bind-key -T root WheelDownPane if-shell -F '#{{mouse_any_flag}}' 'send-keys -M' 'send-keys -X scroll-down'",
+            f"tmux bind-key -T copy-mode-vi WheelUpPane send-keys -X scroll-up",
+            f"tmux bind-key -T copy-mode-vi WheelDownPane send-keys -X scroll-down",
             # Status bar: green connection indicator at the bottom
             f"tmux set-option -t {q(name)} status on",
             f"tmux set-option -t {q(name)} status-position bottom",
@@ -761,6 +767,11 @@ class HermesGateApp(App):
             pass
         commands = " && ".join([
             f"tmux set-option -t {q(name)} prefix C-b",
+            f"tmux set-option -u -t {q(name)} mouse",
+            f"tmux unbind-key -T root WheelUpPane",
+            f"tmux unbind-key -T root WheelDownPane",
+            f"tmux unbind-key -T copy-mode-vi WheelUpPane",
+            f"tmux unbind-key -T copy-mode-vi WheelDownPane",
             f"tmux set-option -u -t {q(name)} status-style",
             f"tmux set-option -u -t {q(name)} status-left",
             f"tmux set-option -u -t {q(name)} status-left-length",

--- a/tests/test_attach_mouse_scroll.py
+++ b/tests/test_attach_mouse_scroll.py
@@ -1,0 +1,57 @@
+from unittest.mock import patch
+
+import pytest
+
+pytest.importorskip("textual")
+
+from hermes_gate.app import HermesGateApp
+from hermes_gate.session import SessionManager
+
+
+def _fake_completed_process():
+    class _Result:
+        returncode = 0
+        stdout = ""
+        stderr = ""
+
+    return _Result()
+
+
+def test_configure_tmux_for_attach_enables_mouse_scrolling_passthrough():
+    """Attach path should configure tmux so wheel events scroll pane history instead of becoming app up/down input."""
+    app = HermesGateApp()
+    mgr = SessionManager("user", "example.com", "22")
+
+    with patch("hermes_gate.app.subprocess.run", return_value=_fake_completed_process()) as run_mock:
+        app._configure_tmux_for_attach(mgr, "gate-7")
+
+    remote_cmd = run_mock.call_args.args[0][-1]
+    assert "set-option -t gate-7 mouse on" in remote_cmd
+    assert "bind-key -T root WheelUpPane" in remote_cmd
+    assert "#{mouse_any_flag}" in remote_cmd
+    assert "send-keys -M" in remote_cmd
+    assert "copy-mode -e" in remote_cmd
+    assert "bind-key -T copy-mode-vi WheelUpPane send-keys -X scroll-up" in remote_cmd
+    assert "bind-key -T copy-mode-vi WheelDownPane send-keys -X scroll-down" in remote_cmd
+
+
+def test_restore_tmux_after_detach_unsets_mouse_wheel_bindings_when_idle():
+    """Attach-specific mouse bindings should be removed when Hermes Gate is the last client."""
+    app = HermesGateApp()
+    mgr = SessionManager("user", "example.com", "22")
+
+    attached_clients = _fake_completed_process()
+    attached_clients.stdout = "0\n"
+
+    with patch(
+        "hermes_gate.app.subprocess.run",
+        side_effect=[attached_clients, _fake_completed_process()],
+    ) as run_mock:
+        app._restore_tmux_after_detach(mgr, "gate-7")
+
+    restore_cmd = run_mock.call_args_list[1].args[0][-1]
+    assert "set-option -u -t gate-7 mouse" in restore_cmd
+    assert "unbind-key -T root WheelUpPane" in restore_cmd
+    assert "unbind-key -T root WheelDownPane" in restore_cmd
+    assert "unbind-key -T copy-mode-vi WheelUpPane" in restore_cmd
+    assert "unbind-key -T copy-mode-vi WheelDownPane" in restore_cmd


### PR DESCRIPTION
## Summary

This PR restores usable mouse-wheel scrolling when attaching to a remote Hermes session through Hermes Gate.

After entering attach mode, mouse wheel movement could fall through as Hermes history navigation instead of behaving like tmux scrollback. This made attach mode feel worse than a direct SSH + tmux workflow.

This PR adds attach-scoped tmux mouse handling and restores the previous tmux state on detach.

## Changes

- enable attach-scoped tmux mouse support during Hermes Gate attach
- add wheel bindings so mouse-wheel scrolling enters tmux scrollback / copy-mode behavior instead of falling through as Hermes history navigation
- restore tmux mouse-related settings and bindings after detach
- add regression tests covering attach-time tmux mouse configuration and detach-time cleanup

## Testing

- `python -m pytest -q tests/test_attach_mouse_scroll.py`

## Risk / Notes

- This PR touches attach-time tmux behavior only
- The change is intentionally attach-scoped and paired with cleanup on detach
- The goal is to restore expected scrolling behavior without broadening Hermes Gate’s product contract
