### PR TITLE
fix: align run.ps1 with run.sh lifecycle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## 2026-04-19 - Windows launcher full run.sh parity
+
+### Fixed
+
+- Reworked `run.ps1` to follow the same control flow as `run.sh`: `stop`, `update -> rebuild`, `rebuild`, smart container/image detection, `docker exec -it ... python -m hermes_gate`, and idle-only auto-stop.
+- Removed runtime generation of `docker-compose.win.yml`; Windows startup now uses a checked-in `docker-compose.windows.yml` so the script no longer owns compose templating or PowerShell-specific UTF-8 file writing.
+- Matched `run.sh` rebuild semantics by using `docker compose down --rmi local` before `up -d --build` on Windows.
+- Added a checked-in Windows compose file that keeps the shared SSH/code mounts while omitting the Linux-only `/etc/hosts` bind.
+
+### Tests
+
+- Expanded `tests/test_run_ps1.py` to lock checked-in Windows compose usage, rebuild parity with `run.sh`, and the Windows compose mount contract.
+- Validation run: `python -m pytest -q tests/test_run_ps1.py` (`7 passed`).
+- Validation run: `python -m pytest -q` (`76 passed`).
+- Validation run: `python -m compileall -q hermes_gate tests`.
+- Validation run: `docker compose -f docker-compose.windows.yml config`.
+
 ## 2026-04-19 - Windows launcher parity and PowerShell 5.1 compatibility
 
 ### Fixed

--- a/docker-compose.windows.yml
+++ b/docker-compose.windows.yml
@@ -1,0 +1,11 @@
+services:
+  hermes-gate:
+    image: hermes-gate
+    build: .
+    container_name: hermes-gate
+    volumes:
+      - ~/.ssh:/host/.ssh:ro
+      - ./hermes_gate:/app/hermes_gate
+    stdin_open: true
+    tty: true
+    restart: unless-stopped

--- a/run.ps1
+++ b/run.ps1
@@ -19,33 +19,7 @@ param(
 $ErrorActionPreference = "Stop"
 $ContainerName = "hermes-gate"
 $ProjectDir = $PSScriptRoot
-
-function Write-Utf8NoBomFile([string]$Path, [string]$Content) {
-    $utf8NoBom = New-Object System.Text.UTF8Encoding($false)
-    [System.IO.File]::WriteAllText($Path, $Content, $utf8NoBom)
-}
-
-# ---------------------------------------------------------------------------
-# Docker Compose on Windows cannot mount /etc/hosts (Linux/macOS only).
-# Generate a Windows-specific compose file deterministically on each run.
-# ---------------------------------------------------------------------------
-function Get-ComposeFile {
-    $winCompose = Join-Path $ProjectDir "docker-compose.win.yml"
-    $composeContent = @"
-services:
-  hermes-gate:
-    build: .
-    container_name: hermes-gate
-    volumes:
-      - `${HOME}/.ssh:/host/.ssh:ro
-      - ./hermes_gate:/app/hermes_gate
-    stdin_open: true
-    tty: true
-    restart: unless-stopped
-"@
-    Write-Utf8NoBomFile -Path $winCompose -Content $composeContent
-    return $winCompose
-}
+$ComposeArgs = @("-f", "docker-compose.windows.yml")
 
 function Assert-Command([string]$Name, [string]$Message) {
     if (-not (Get-Command $Name -ErrorAction SilentlyContinue)) {
@@ -87,7 +61,7 @@ function Invoke-Tui([string]$Name) {
 }
 
 function Stop-IfIdle([string]$Name) {
-    $remaining = docker exec $Name sh -lc "pgrep -fc 'python -m hermes_gate'" 2>$null
+    $remaining = docker exec $Name pgrep -c python 2>$null
     if ($LASTEXITCODE -ne 0) {
         $remaining = "0"
     }
@@ -102,7 +76,6 @@ function Stop-IfIdle([string]$Name) {
 }
 
 function Launch-Tui([string]$Name) {
-    Write-Host "Launching TUI..."
     try {
         Invoke-Tui $Name
     }
@@ -111,9 +84,6 @@ function Launch-Tui([string]$Name) {
     }
 }
 
-# ---------------------------------------------------------------------------
-# Main
-# ---------------------------------------------------------------------------
 Set-Location $ProjectDir
 
 Assert-Command -Name docker -Message "Error: Docker not found. Please install Docker Desktop for Windows."
@@ -125,9 +95,6 @@ if ($Command -eq "update") {
     Assert-Command -Name git -Message "Error: git not found. Please install Git before using '.\run.ps1 update'."
 }
 
-$ComposeFile = Get-ComposeFile
-$ComposeArgs = @("-f", $ComposeFile)
-
 if ($Command -eq "stop") {
     Write-Host "Stopping $ContainerName..."
     docker compose @ComposeArgs down 2>$null
@@ -138,49 +105,41 @@ if ($Command -eq "stop") {
     exit 0
 }
 
-# --- update ---
 if ($Command -eq "update") {
     Write-Host "Pulling latest changes..."
     git pull
     $Command = "rebuild"
 }
 
-# --- rebuild ---
 if ($Command -eq "rebuild") {
     Write-Host "Force rebuilding..."
-    docker compose @ComposeArgs down 2>$null | Out-Null
+    docker compose @ComposeArgs down --rmi local 2>$null | Out-Null
     docker compose @ComposeArgs up -d --build
-    Write-Host "Build complete."
+    Write-Host "Build complete, launching TUI..."
     Launch-Tui $ContainerName
     exit 0
 }
 
-# --- default: smart start ---
 $running = docker inspect -f '{{.State.Running}}' $ContainerName 2>$null
-if ($running -eq "true") {
-    Write-Host "Container already running."
-    Launch-Tui $ContainerName
-    exit 0
+if ($running -ne "true") {
+    $exists = docker inspect -f '{{.Id}}' $ContainerName 2>$null
+
+    if ($LASTEXITCODE -eq 0 -and $exists) {
+        Write-Host "Container exists (stopped), starting..."
+        docker start $ContainerName | Out-Null
+    }
+    else {
+        $hasImage = docker images --format "{{.Repository}}:{{.Tag}}" | Where-Object { $_ -match "hermes" }
+        if ($hasImage) {
+            Write-Host "Image found, starting container..."
+            docker compose @ComposeArgs up -d
+        }
+        else {
+            Write-Host "No image found, building for the first time..."
+            docker compose @ComposeArgs up -d --build
+        }
+    }
+    Write-Host "Container started, launching TUI..."
 }
 
-if (Test-ContainerExists $ContainerName) {
-    Write-Host "Container exists (stopped), starting..."
-    docker start $ContainerName | Out-Null
-    Write-Host "Started."
-    Launch-Tui $ContainerName
-    exit 0
-}
-
-$hasImage = docker images --format "{{.Repository}}:{{.Tag}}" | Where-Object { $_ -match "hermes" }
-if ($hasImage) {
-    Write-Host "Image found, starting container (skip build)..."
-    docker compose @ComposeArgs up -d
-    Write-Host "Started."
-    Launch-Tui $ContainerName
-    exit 0
-}
-
-Write-Host "No image found, building for the first time..."
-docker compose @ComposeArgs up -d --build
-Write-Host "Build complete."
 Launch-Tui $ContainerName

--- a/tests/test_run_ps1.py
+++ b/tests/test_run_ps1.py
@@ -26,7 +26,34 @@ def test_run_ps1_avoids_utf8nobom_encoding_for_ps51_compatibility():
     """PowerShell 5.1-compatible compose writing should not rely on UTF8NoBOM."""
     content = _run_ps1()
     assert 'UTF8NoBOM' not in content
-    assert 'System.Text.UTF8Encoding($false)' in content
+    assert 'System.Text.UTF8Encoding($false)' not in content
+
+
+def test_run_ps1_uses_checked_in_windows_compose_override():
+    """Windows launcher should use the checked-in Windows compose file instead of generating one on the fly."""
+    content = _run_ps1()
+    assert '$ComposeArgs = @("-f", "docker-compose.windows.yml")' in content
+    assert 'docker-compose.win.yml' not in content
+    assert 'Write-Utf8NoBomFile' not in content
+
+
+def test_run_ps1_rebuild_matches_run_sh_image_cleanup_behavior():
+    """Windows rebuild flow should match run.sh by removing local images before rebuild."""
+    content = _run_ps1()
+    assert 'docker compose @ComposeArgs down --rmi local' in content
+
+
+def test_windows_compose_override_removes_hosts_mount_only():
+    """Windows compose file should keep the shared mounts but omit the Linux-only /etc/hosts bind."""
+    content = (ROOT / "docker-compose.windows.yml").read_text(encoding="utf-8")
+    assert 'services:' in content
+    assert 'hermes-gate:' in content
+    assert 'image: hermes-gate' in content
+    assert 'build: .' in content
+    assert 'container_name: hermes-gate' in content
+    assert '~/.ssh:/host/.ssh:ro' in content
+    assert './hermes_gate:/app/hermes_gate' in content
+    assert '/etc/hosts:/host/etc/hosts:ro' not in content
 
 
 def test_readme_documents_windows_stop_command():


### PR DESCRIPTION
## Summary

This PR aligns the Windows launcher with the current `run.sh` lifecycle model so both platforms follow the same startup and shutdown behavior.

Previously, `run.ps1` had drifted from the canonical runtime model:
- it owned Windows-specific compose generation at runtime
- its control flow was no longer a clean match for `run.sh`
- platform behavior risked drifting again whenever launcher logic changed upstream

This PR makes `run.ps1` behave like `run.sh`, while keeping Windows-specific Docker differences in a checked-in compose file.

## Changes

- align `run.ps1` control flow with `run.sh`
  - `stop`
  - `update -> rebuild`
  - `rebuild`
  - smart start for running / stopped / image-present / first-build cases
- keep TUI launch on Windows on the same runtime model as Linux/macOS
  - use `docker exec -it hermes-gate python -m hermes_gate`
  - do not rely on `docker attach`
- preserve idle-only container auto-stop behavior on Windows
  - after TUI exit, stop the container only when no other local session remains
- replace runtime-generated `docker-compose.win.yml` with a checked-in `docker-compose.windows.yml`
- keep Windows-specific compose behavior explicit and reviewable
  - keep SSH and source mounts
  - omit the Linux-only `/etc/hosts` bind
- match `run.sh` rebuild semantics by using `docker compose down --rmi local` before rebuild
- expand regression coverage for Windows launcher behavior

## Testing

- `python -m pytest -q tests/test_run_ps1.py`
- `docker compose -f docker-compose.windows.yml config`

## Risk / Notes

- This PR changes only the Windows launcher path
- Linux/macOS launcher behavior is unchanged
- The goal is launcher parity, not a broader product-behavior change
- Using a checked-in Windows compose file should reduce future drift compared with PowerShell-generated YAML
