### PR TITLE
fix: harden windows notifications and add response previews

### DIFF
--- a/hermes_gate/app.py
+++ b/hermes_gate/app.py
@@ -259,214 +259,38 @@ class HermesGateApp(App):
 
     def _show_server_select(self) -> None:
         self._phase = "select"
-        self._stop_auto_refresh()
         self._clear()
 
-        servers = load_servers()
-        items = [ListItem(Label(f" 🖥️  {display_name(s)}"), name="srv") for s in servers]
-        items.append(ListItem(Label(" ➕  Add Server..."), name="new-srv"))
-
+        server_entries = load_servers()
         self.mount(
             Center(
                 Vertical(
                     Label("⚡ Hermes Gate — Select Server", id="server-title"),
-                    ListView(*items, id="server-list"),
-                    Label(
-                        "↑↓ Select · Enter Connect · D Delete · Q Quit",
-                        id="server-hint",
-                    ),
+                    ListView(id="server-list"),
+                    Label("↑↓ Select · Enter Connect · d Delete · q Quit", id="server-hint"),
                     id="server-box",
                 ),
                 id="server-screen",
             )
         )
-        self.query_one("#server-list", ListView).focus()
-
-    def on_list_view_selected(self, event: ListView.Selected) -> None:
-        if self._phase == "select":
-            self._on_server_selected(event)
-        elif self._phase == "session":
-            self._on_session_selected(event)
-
-    def _on_server_selected(self, event: ListView.Selected) -> None:
-        idx = event.list_view.index
-        if idx is None:
-            return
-        servers = load_servers()
-        if idx >= len(servers):
-            self._prompt_new_server()
-        else:
-            self._connect_server(servers[idx])
-
-    def action_noop(self) -> None:
-        pass
-
-    def check_action(self, action: str, parameters: tuple[object, ...]) -> bool | None:
-        session_actions = {"new_session", "kill_session", "refresh", "attach_session", "back"}
-        select_actions = {"delete_server"}
-
-        if action in session_actions:
-            return self._phase == "session"
-        if action in select_actions:
-            return self._phase == "select"
-        return True
-
-    def action_delete_server(self) -> None:
-        """D key to delete selected server (only removes from servers.json)"""
-        if self._phase != "select":
-            return
         lv = self.query_one("#server-list", ListView)
-        idx = lv.index
-        if idx is None:
-            return
-        servers = load_servers()
-        if idx >= len(servers):
-            return
-        server = servers[idx]
-        name = display_name(server)
+        for server in server_entries:
+            alias = find_ssh_alias(server["user"], server["host"], server.get("port", "22"))
+            name = alias or display_name(server)
+            lv.append(ListItem(Label(f" {name}"), name="srv"))
+        lv.append(ListItem(Label(" ➕  Add Server..."), name="add-srv"))
+        lv.focus()
 
-        from hermes_gate.servers import remove_server
-
-        remove_server(server["user"], server["host"], server.get("port", "22"))
-        self._hint("server-hint", f"Deleted {name}")
-        self._show_server_select()
-
-    def _prompt_new_server(self) -> None:
-        def handle(result: str | None):
-            if not result or not result.strip():
-                return
-            text = result.strip()
-
-            # Try resolving as SSH config alias (e.g. "prod-server")
-            from hermes_gate.servers import resolve_ssh_config
-
-            ssh_cfg = resolve_ssh_config(text)
-            if ssh_cfg:
-                ssh_cfg["ssh_alias"] = text
-                self._connect_server(ssh_cfg, new=True)
-                return
-
-            # Parse user@host[:port] format
-            if "@" not in text:
-                self._hint("server-hint", "Invalid format. Use user@host or SSH alias")
-                return
-            user, host_port = text.split("@", 1)
-            user = user.strip()
-            if ":" in host_port:
-                host, port = host_port.rsplit(":", 1)
-                host, port = host.strip(), port.strip()
-            else:
-                host, port = host_port.strip(), "22"
-            if not user or not host:
-                self._hint("server-hint", "Username and host cannot be empty")
-                return
-            self._connect_server({"user": user, "host": host, "port": port}, new=True)
-
-        self.push_screen(NewServerScreen(), handle)
-
-    # ─── Connect Server ────────────────────────────────────────────
-
-    def _connect_server(self, server: dict, new: bool = False) -> None:
-        user, host = server["user"], server["host"]
-        port = server.get("port", "22")
-        ssh_alias = server.get("ssh_alias") or find_ssh_alias(user, host, port)
-        if ssh_alias:
-            server = {**server, "ssh_alias": ssh_alias}
-        name = display_name(server)
-        scr = ConnectingScreen(f"🔍 Connecting to {name} ...")
-        self.push_screen(scr)
-
-        async def _do():
-            scr.update_msg(f"🔍 Testing SSH connection to {name} ...")
-            if not await self._ssh_ok(user, host, port, ssh_alias):
-                self.pop_screen()
-                self._hint(
-                    "server-hint",
-                    f"Cannot connect to {name}, check address and keys"
-                    if new
-                    else f"Cannot connect to {name}",
-                )
-                return
-            scr.update_msg(f"🔍 Checking tmux on {name} ...")
-            if not await self._remote_command_ok(
-                user, host, port, "bash -l -c 'command -v tmux >/dev/null'", ssh_alias
-            ):
-                self.pop_screen()
-                self._hint("server-hint", "Please install tmux on the server")
-                return
-            scr.update_msg(f"🔍 Checking hermes on {name} ...")
-            if not await self._hermes_ok(user, host, port, ssh_alias):
-                self.pop_screen()
-                self._hint("server-hint", "Please install hermes on the server")
-                return
-            if new:
-                add_server(user, host, port, ssh_alias=ssh_alias)
-            self._server = {**server, "ssh_alias": ssh_alias} if ssh_alias else server
-            self.pop_screen()
-            self._show_session_list(user, host, port, ssh_alias)
-
-        self.run_worker(_do(), exclusive=True)
-
-    async def _ssh_ok(
-        self, user: str, host: str, port: str = "22", ssh_alias: str | None = None
-    ) -> bool:
+    def _hint(self, label_id: str, msg: str, error: bool = True) -> None:
         try:
-            mgr = SessionManager(user, host, port, ssh_alias=ssh_alias)
-            p = await asyncio.create_subprocess_exec(
-                *mgr.ssh_base_args(timeout=8),
-                "echo",
-                "ok",
-                stdout=asyncio.subprocess.PIPE,
-                stderr=asyncio.subprocess.PIPE,
-            )
-            out, _ = await asyncio.wait_for(p.communicate(), timeout=15)
-            return p.returncode == 0 and b"ok" in out
-        except Exception:
-            return False
-
-    async def _hermes_ok(
-        self, user: str, host: str, port: str = "22", ssh_alias: str | None = None
-    ) -> bool:
-        return await self._remote_command_ok(
-            user,
-            host,
-            port,
-            "bash -l -c 'command -v hermes >/dev/null && hermes --version >/dev/null'",
-            ssh_alias,
-        )
-
-    async def _remote_command_ok(
-        self,
-        user: str,
-        host: str,
-        port: str,
-        remote_command: str,
-        ssh_alias: str | None = None,
-    ) -> bool:
-        try:
-            mgr = SessionManager(user, host, port, ssh_alias=ssh_alias)
-            p = await asyncio.create_subprocess_exec(
-                *mgr.ssh_base_args(timeout=8),
-                remote_command,
-                stdout=asyncio.subprocess.PIPE,
-                stderr=asyncio.subprocess.PIPE,
-            )
-            out, _ = await asyncio.wait_for(p.communicate(), timeout=15)
-            return p.returncode == 0
-        except Exception:
-            return False
-
-    def _hint(self, hint_id: str, msg: str, error: bool = True) -> None:
-        try:
-            h = self.query_one(f"#{hint_id}", Label)
-            prefix = "❌" if error else "✅"
-            h.update(f"{prefix} {msg}")
+            h = self.query_one(f"#{label_id}", Label)
+            reset_text = None
+            if label_id == "server-hint":
+                reset_text = "↑↓ Select · Enter Connect · d Delete · q Quit"
+            elif label_id == "session-hint":
+                reset_text = "↑↓ Select · Enter Attach · n New · k Kill · r Refresh · Ctrl+B Back · q Quit"
+            h.update(msg)
             h.styles.color = "red" if error else "green"
-
-            reset_text = {
-                "server-hint": "↑↓ Select · Enter Connect · D Delete · Q Quit",
-                "session-hint": "↑↓ Select · Enter Attach · n New · k Kill · r Refresh · Ctrl+B Back · q Quit",
-            }.get(hint_id, "")
 
             def reset_hint() -> None:
                 if reset_text:
@@ -547,6 +371,25 @@ class HermesGateApp(App):
             self._refresh_sessions()
             self._check_completion()
 
+    def _emit_host_notification(
+        self,
+        title: str,
+        message: str,
+        sound: str = "complete.wav",
+        **extra: str,
+    ) -> None:
+        notify_dir = Path("/hermes-notify")
+        if not notify_dir.is_dir():
+            return
+        ts = datetime.now().strftime("%Y%m%d%H%M%S%f")
+        payload = {
+            "title": title,
+            "message": message,
+            "sound": sound,
+            **extra,
+        }
+        (notify_dir / f"notify-{ts}.json").write_text(json.dumps(payload))
+
     def _notify(self, session_name: str, message: str) -> None:
         """Dual-layer notification: OSC 9 (instant terminal) + file signal (host system)."""
         text = f"Hermes {session_name}: {message}"
@@ -559,16 +402,12 @@ class HermesGateApp(App):
             pass
 
         # Layer 2: Write file signal to mounted volume for host-side watcher
-        notify_dir = Path("/hermes-notify")
-        if notify_dir.is_dir():
-            ts = datetime.now().strftime("%Y%m%d%H%M%S%f")
-            (notify_dir / f"notify-{ts}.json").write_text(
-                json.dumps({
-                    "title": "Hermes Gate",
-                    "message": text,
-                    "sound": "complete.wav",
-                })
-            )
+        self._emit_host_notification(
+            "Hermes Gate",
+            text,
+            session_name=session_name,
+            response_preview=message,
+        )
 
     @work(exit_on_error=False)
     async def _check_completion(self) -> None:
@@ -583,7 +422,7 @@ class HermesGateApp(App):
             return
         for sig in signals:
             name = f"gate-{sig.get('session_id', '?')}"
-            preview = sig.get("message_preview", "task completed")
+            preview = sig.get("response_preview") or sig.get("message_preview") or "task completed"
             self._notify(name, preview)
 
     @work(exit_on_error=False)
@@ -687,26 +526,22 @@ class HermesGateApp(App):
         screen = WaitingScreen(f"Waiting for {name} to be killed...")
         self.push_screen(screen)
 
-        async def _do_kill() -> None:
-            await self._do_kill_session(sid, screen)
+        async def do_kill() -> None:
+            try:
+                loop = asyncio.get_event_loop()
+                result = await loop.run_in_executor(None, self.session_mgr.kill_session, sid)
+            except Exception as e:
+                screen.set_error(f"Kill failed: {e}")
+                return
 
-        self.run_worker(_do_kill(), exit_on_error=False)
+            self.pop_screen()
+            if result.get("tmux_missing"):
+                self._hint("session-hint", f"{name} killed, local record removed", error=False)
+            else:
+                self._hint("session-hint", f"{name} killed", error=False)
+            self._refresh_sessions()
 
-    async def _do_kill_session(self, sid: int, screen: WaitingScreen) -> None:
-        name = f"gate-{sid}"
-        loop = asyncio.get_event_loop()
-        try:
-            result = await loop.run_in_executor(None, self.session_mgr.kill_session, sid)
-        except Exception as e:
-            screen.set_error(f"Failed to kill {name}: {e}")
-            return
-
-        self.pop_screen()
-        if result.get("tmux_missing"):
-            self._hint("session-hint", f"{name} killed, local record removed", error=False)
-        else:
-            self._hint("session-hint", f"{name} killed", error=False)
-        self._refresh_sessions()
+        asyncio.create_task(do_kill())
 
     # ═══════════════════════════════════════════════════════════════
     # Step 3: Attach to Remote tmux Session
@@ -727,7 +562,11 @@ class HermesGateApp(App):
 
         # Stop network monitor before suspending
         if self.net_monitor:
-            asyncio.create_task(self.net_monitor.stop())
+            try:
+                loop = asyncio.get_running_loop()
+                loop.create_task(self.net_monitor.stop())
+            except RuntimeError:
+                asyncio.run(self.net_monitor.stop())
             self.net_monitor = None
 
         # Configure tmux: Ctrl+B → detach, green status bar at bottom
@@ -775,23 +614,18 @@ class HermesGateApp(App):
         self._bg_poll_stop = threading.Event()
 
         def _poll():
-            notify_dir = Path("/hermes-notify")
             while not self._bg_poll_stop.is_set():
                 try:
                     signals = mgr.check_completion_signals()
                     for sig in signals:
                         name = f"gate-{sig.get('session_id', '?')}"
-                        preview = sig.get("message_preview", "task completed")
-                        text = f"Hermes {name}: {preview}"
-                        if notify_dir.is_dir():
-                            ts = datetime.now().strftime("%Y%m%d%H%M%S%f")
-                            (notify_dir / f"notify-{ts}.json").write_text(
-                                json.dumps({
-                                    "title": "Hermes Gate",
-                                    "message": text,
-                                    "sound": "complete.wav",
-                                })
-                            )
+                        preview = sig.get("response_preview") or sig.get("message_preview") or "task completed"
+                        self._emit_host_notification(
+                            "Hermes Gate",
+                            f"{name}: {preview}",
+                            session_name=name,
+                            response_preview=preview,
+                        )
                 except Exception:
                     pass
                 self._bg_poll_stop.wait(3)
@@ -883,6 +717,7 @@ class HermesGateApp(App):
             f"tmux set-option -u -t {q(name)} status-right",
             f"tmux set-option -u -t {q(name)} status-right-length",
             f"tmux set-option -u -t {q(name)} status-right-style",
+            f"tmux unbind-key -T root C-b",
         ])
         remote_cmd = f"bash -l -c {q(commands)}"
 
@@ -897,32 +732,9 @@ class HermesGateApp(App):
 
     # ─── Navigation ────────────────────────────────────────────────
 
-    def action_attach_session(self) -> None:
-        """Enter key to attach session"""
-        if self._phase != "session":
-            return
-        idx = self.query_one("#session-list", ListView).index
-        if idx is None or idx >= len(self.sessions):
-            return
-        s = self.sessions[idx]
-        if not s.get("alive"):
-            self._hint("session-hint", f"{s['name']} is dead, please refresh")
-            return
-        self._enter_viewer(s["id"])
-
-    def check_action(self, action: str, parameters: tuple[object, ...]) -> bool | None:
-        if action == "delete_server":
-            return self._phase == "select"
-        if action in {"new_session", "kill_session", "refresh", "attach_session", "back"}:
-            return self._phase == "session"
-        return True
-
     def action_back(self) -> None:
-        """Ctrl+B — Go back to previous level
-
-        session list → server selection
-        """
-        # Stop network monitor (all back scenarios)
+        if self._phase == "select":
+            return
         if self.net_monitor:
             try:
                 loop = asyncio.get_running_loop()
@@ -930,12 +742,13 @@ class HermesGateApp(App):
             except RuntimeError:
                 asyncio.run(self.net_monitor.stop())
             self.net_monitor = None
+        self._stop_auto_refresh()
+        self._show_server_select()
 
-        if self._phase == "session":
-            # Return to server selection
-            self._show_server_select()
 
-    async def on_shutdown_request(self) -> None:
-        if self.net_monitor:
-            await self.net_monitor.stop()
-        await super().on_shutdown_request()
+def main() -> None:
+    HermesGateApp().run(mouse=False)
+
+
+if __name__ == "__main__":
+    main()

--- a/hermes_gate/app.py
+++ b/hermes_gate/app.py
@@ -585,6 +585,14 @@ class HermesGateApp(App):
             response_preview=message,
         )
 
+    @staticmethod
+    def _get_preview(sig: dict) -> str:
+        """Prefer assistant response preview, then legacy message preview, then default text.
+
+        Empty strings intentionally fall through to the next option.
+        """
+        return sig.get("response_preview") or sig.get("message_preview") or "task completed"
+
     @work(exit_on_error=False)
     async def _check_completion(self) -> None:
         if not self.session_mgr:
@@ -598,7 +606,7 @@ class HermesGateApp(App):
             return
         for sig in signals:
             name = f"gate-{sig.get('session_id', '?')}"
-            preview = sig.get("response_preview") or sig.get("message_preview") or "task completed"
+            preview = self._get_preview(sig)
             self._notify(name, preview)
 
     @work(exit_on_error=False)
@@ -795,13 +803,10 @@ class HermesGateApp(App):
                     signals = mgr.check_completion_signals()
                     for sig in signals:
                         name = f"gate-{sig.get('session_id', '?')}"
-                        preview = sig.get("response_preview") or sig.get("message_preview") or "task completed"
-                        self._emit_host_notification(
-                            "Hermes Gate",
-                            f"Hermes {name}: {preview}",
-                            session_name=name,
-                            response_preview=preview,
-                        )
+                        preview = self._get_preview(sig)
+                        # Keep attached-session notifications on the same OSC 9 + host-file path
+                        # as foreground completion checks so terminal and host behavior stay aligned.
+                        self._notify(name, preview)
                 except Exception:
                     pass
                 self._bg_poll_stop.wait(3)

--- a/hermes_gate/app.py
+++ b/hermes_gate/app.py
@@ -259,38 +259,214 @@ class HermesGateApp(App):
 
     def _show_server_select(self) -> None:
         self._phase = "select"
+        self._stop_auto_refresh()
         self._clear()
 
-        server_entries = load_servers()
+        servers = load_servers()
+        items = [ListItem(Label(f" 🖥️  {display_name(s)}"), name="srv") for s in servers]
+        items.append(ListItem(Label(" ➕  Add Server..."), name="new-srv"))
+
         self.mount(
             Center(
                 Vertical(
                     Label("⚡ Hermes Gate — Select Server", id="server-title"),
-                    ListView(id="server-list"),
-                    Label("↑↓ Select · Enter Connect · d Delete · q Quit", id="server-hint"),
+                    ListView(*items, id="server-list"),
+                    Label(
+                        "↑↓ Select · Enter Connect · D Delete · Q Quit",
+                        id="server-hint",
+                    ),
                     id="server-box",
                 ),
                 id="server-screen",
             )
         )
-        lv = self.query_one("#server-list", ListView)
-        for server in server_entries:
-            alias = find_ssh_alias(server["user"], server["host"], server.get("port", "22"))
-            name = alias or display_name(server)
-            lv.append(ListItem(Label(f" {name}"), name="srv"))
-        lv.append(ListItem(Label(" ➕  Add Server..."), name="add-srv"))
-        lv.focus()
+        self.query_one("#server-list", ListView).focus()
 
-    def _hint(self, label_id: str, msg: str, error: bool = True) -> None:
+    def on_list_view_selected(self, event: ListView.Selected) -> None:
+        if self._phase == "select":
+            self._on_server_selected(event)
+        elif self._phase == "session":
+            self._on_session_selected(event)
+
+    def _on_server_selected(self, event: ListView.Selected) -> None:
+        idx = event.list_view.index
+        if idx is None:
+            return
+        servers = load_servers()
+        if idx >= len(servers):
+            self._prompt_new_server()
+        else:
+            self._connect_server(servers[idx])
+
+    def action_noop(self) -> None:
+        pass
+
+    def check_action(self, action: str, parameters: tuple[object, ...]) -> bool | None:
+        session_actions = {"new_session", "kill_session", "refresh", "attach_session", "back"}
+        select_actions = {"delete_server"}
+
+        if action in session_actions:
+            return self._phase == "session"
+        if action in select_actions:
+            return self._phase == "select"
+        return True
+
+    def action_delete_server(self) -> None:
+        """D key to delete selected server (only removes from servers.json)"""
+        if self._phase != "select":
+            return
+        lv = self.query_one("#server-list", ListView)
+        idx = lv.index
+        if idx is None:
+            return
+        servers = load_servers()
+        if idx >= len(servers):
+            return
+        server = servers[idx]
+        name = display_name(server)
+
+        from hermes_gate.servers import remove_server
+
+        remove_server(server["user"], server["host"], server.get("port", "22"))
+        self._hint("server-hint", f"Deleted {name}")
+        self._show_server_select()
+
+    def _prompt_new_server(self) -> None:
+        def handle(result: str | None):
+            if not result or not result.strip():
+                return
+            text = result.strip()
+
+            # Try resolving as SSH config alias (e.g. "prod-server")
+            from hermes_gate.servers import resolve_ssh_config
+
+            ssh_cfg = resolve_ssh_config(text)
+            if ssh_cfg:
+                ssh_cfg["ssh_alias"] = text
+                self._connect_server(ssh_cfg, new=True)
+                return
+
+            # Parse user@host[:port] format
+            if "@" not in text:
+                self._hint("server-hint", "Invalid format. Use user@host or SSH alias")
+                return
+            user, host_port = text.split("@", 1)
+            user = user.strip()
+            if ":" in host_port:
+                host, port = host_port.rsplit(":", 1)
+                host, port = host.strip(), port.strip()
+            else:
+                host, port = host_port.strip(), "22"
+            if not user or not host:
+                self._hint("server-hint", "Username and host cannot be empty")
+                return
+            self._connect_server({"user": user, "host": host, "port": port}, new=True)
+
+        self.push_screen(NewServerScreen(), handle)
+
+    # ─── Connect Server ────────────────────────────────────────────
+
+    def _connect_server(self, server: dict, new: bool = False) -> None:
+        user, host = server["user"], server["host"]
+        port = server.get("port", "22")
+        ssh_alias = server.get("ssh_alias") or find_ssh_alias(user, host, port)
+        if ssh_alias:
+            server = {**server, "ssh_alias": ssh_alias}
+        name = display_name(server)
+        scr = ConnectingScreen(f"🔍 Connecting to {name} ...")
+        self.push_screen(scr)
+
+        async def _do():
+            scr.update_msg(f"🔍 Testing SSH connection to {name} ...")
+            if not await self._ssh_ok(user, host, port, ssh_alias):
+                self.pop_screen()
+                self._hint(
+                    "server-hint",
+                    f"Cannot connect to {name}, check address and keys"
+                    if new
+                    else f"Cannot connect to {name}",
+                )
+                return
+            scr.update_msg(f"🔍 Checking tmux on {name} ...")
+            if not await self._remote_command_ok(
+                user, host, port, "bash -l -c 'command -v tmux >/dev/null'", ssh_alias
+            ):
+                self.pop_screen()
+                self._hint("server-hint", "Please install tmux on the server")
+                return
+            scr.update_msg(f"🔍 Checking hermes on {name} ...")
+            if not await self._hermes_ok(user, host, port, ssh_alias):
+                self.pop_screen()
+                self._hint("server-hint", "Please install hermes on the server")
+                return
+            if new:
+                add_server(user, host, port, ssh_alias=ssh_alias)
+            self._server = {**server, "ssh_alias": ssh_alias} if ssh_alias else server
+            self.pop_screen()
+            self._show_session_list(user, host, port, ssh_alias)
+
+        self.run_worker(_do(), exclusive=True)
+
+    async def _ssh_ok(
+        self, user: str, host: str, port: str = "22", ssh_alias: str | None = None
+    ) -> bool:
         try:
-            h = self.query_one(f"#{label_id}", Label)
-            reset_text = None
-            if label_id == "server-hint":
-                reset_text = "↑↓ Select · Enter Connect · d Delete · q Quit"
-            elif label_id == "session-hint":
-                reset_text = "↑↓ Select · Enter Attach · n New · k Kill · r Refresh · Ctrl+B Back · q Quit"
-            h.update(msg)
+            mgr = SessionManager(user, host, port, ssh_alias=ssh_alias)
+            p = await asyncio.create_subprocess_exec(
+                *mgr.ssh_base_args(timeout=8),
+                "echo",
+                "ok",
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+            )
+            out, _ = await asyncio.wait_for(p.communicate(), timeout=15)
+            return p.returncode == 0 and b"ok" in out
+        except Exception:
+            return False
+
+    async def _hermes_ok(
+        self, user: str, host: str, port: str = "22", ssh_alias: str | None = None
+    ) -> bool:
+        return await self._remote_command_ok(
+            user,
+            host,
+            port,
+            "bash -l -c 'command -v hermes >/dev/null && hermes --version >/dev/null'",
+            ssh_alias,
+        )
+
+    async def _remote_command_ok(
+        self,
+        user: str,
+        host: str,
+        port: str,
+        remote_command: str,
+        ssh_alias: str | None = None,
+    ) -> bool:
+        try:
+            mgr = SessionManager(user, host, port, ssh_alias=ssh_alias)
+            p = await asyncio.create_subprocess_exec(
+                *mgr.ssh_base_args(timeout=8),
+                remote_command,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+            )
+            out, _ = await asyncio.wait_for(p.communicate(), timeout=15)
+            return p.returncode == 0
+        except Exception:
+            return False
+
+    def _hint(self, hint_id: str, msg: str, error: bool = True) -> None:
+        try:
+            h = self.query_one(f"#{hint_id}", Label)
+            prefix = "❌" if error else "✅"
+            h.update(f"{prefix} {msg}")
             h.styles.color = "red" if error else "green"
+
+            reset_text = {
+                "server-hint": "↑↓ Select · Enter Connect · D Delete · Q Quit",
+                "session-hint": "↑↓ Select · Enter Attach · n New · k Kill · r Refresh · Ctrl+B Back · q Quit",
+            }.get(hint_id, "")
 
             def reset_hint() -> None:
                 if reset_text:
@@ -526,22 +702,26 @@ class HermesGateApp(App):
         screen = WaitingScreen(f"Waiting for {name} to be killed...")
         self.push_screen(screen)
 
-        async def do_kill() -> None:
-            try:
-                loop = asyncio.get_event_loop()
-                result = await loop.run_in_executor(None, self.session_mgr.kill_session, sid)
-            except Exception as e:
-                screen.set_error(f"Kill failed: {e}")
-                return
+        async def _do_kill() -> None:
+            await self._do_kill_session(sid, screen)
 
-            self.pop_screen()
-            if result.get("tmux_missing"):
-                self._hint("session-hint", f"{name} killed, local record removed", error=False)
-            else:
-                self._hint("session-hint", f"{name} killed", error=False)
-            self._refresh_sessions()
+        self.run_worker(_do_kill(), exit_on_error=False)
 
-        asyncio.create_task(do_kill())
+    async def _do_kill_session(self, sid: int, screen: WaitingScreen) -> None:
+        name = f"gate-{sid}"
+        loop = asyncio.get_event_loop()
+        try:
+            result = await loop.run_in_executor(None, self.session_mgr.kill_session, sid)
+        except Exception as e:
+            screen.set_error(f"Failed to kill {name}: {e}")
+            return
+
+        self.pop_screen()
+        if result.get("tmux_missing"):
+            self._hint("session-hint", f"{name} killed, local record removed", error=False)
+        else:
+            self._hint("session-hint", f"{name} killed", error=False)
+        self._refresh_sessions()
 
     # ═══════════════════════════════════════════════════════════════
     # Step 3: Attach to Remote tmux Session
@@ -562,11 +742,7 @@ class HermesGateApp(App):
 
         # Stop network monitor before suspending
         if self.net_monitor:
-            try:
-                loop = asyncio.get_running_loop()
-                loop.create_task(self.net_monitor.stop())
-            except RuntimeError:
-                asyncio.run(self.net_monitor.stop())
+            asyncio.create_task(self.net_monitor.stop())
             self.net_monitor = None
 
         # Configure tmux: Ctrl+B → detach, green status bar at bottom
@@ -622,7 +798,7 @@ class HermesGateApp(App):
                         preview = sig.get("response_preview") or sig.get("message_preview") or "task completed"
                         self._emit_host_notification(
                             "Hermes Gate",
-                            f"{name}: {preview}",
+                            f"Hermes {name}: {preview}",
                             session_name=name,
                             response_preview=preview,
                         )
@@ -717,7 +893,6 @@ class HermesGateApp(App):
             f"tmux set-option -u -t {q(name)} status-right",
             f"tmux set-option -u -t {q(name)} status-right-length",
             f"tmux set-option -u -t {q(name)} status-right-style",
-            f"tmux unbind-key -T root C-b",
         ])
         remote_cmd = f"bash -l -c {q(commands)}"
 
@@ -732,9 +907,32 @@ class HermesGateApp(App):
 
     # ─── Navigation ────────────────────────────────────────────────
 
-    def action_back(self) -> None:
-        if self._phase == "select":
+    def action_attach_session(self) -> None:
+        """Enter key to attach session"""
+        if self._phase != "session":
             return
+        idx = self.query_one("#session-list", ListView).index
+        if idx is None or idx >= len(self.sessions):
+            return
+        s = self.sessions[idx]
+        if not s.get("alive"):
+            self._hint("session-hint", f"{s['name']} is dead, please refresh")
+            return
+        self._enter_viewer(s["id"])
+
+    def check_action(self, action: str, parameters: tuple[object, ...]) -> bool | None:
+        if action == "delete_server":
+            return self._phase == "select"
+        if action in {"new_session", "kill_session", "refresh", "attach_session", "back"}:
+            return self._phase == "session"
+        return True
+
+    def action_back(self) -> None:
+        """Ctrl+B — Go back to previous level
+
+        session list → server selection
+        """
+        # Stop network monitor (all back scenarios)
         if self.net_monitor:
             try:
                 loop = asyncio.get_running_loop()
@@ -742,13 +940,12 @@ class HermesGateApp(App):
             except RuntimeError:
                 asyncio.run(self.net_monitor.stop())
             self.net_monitor = None
-        self._stop_auto_refresh()
-        self._show_server_select()
 
+        if self._phase == "session":
+            # Return to server selection
+            self._show_server_select()
 
-def main() -> None:
-    HermesGateApp().run(mouse=False)
-
-
-if __name__ == "__main__":
-    main()
+    async def on_shutdown_request(self) -> None:
+        if self.net_monitor:
+            await self.net_monitor.stop()
+        await super().on_shutdown_request()

--- a/run.ps1
+++ b/run.ps1
@@ -81,46 +81,104 @@ function Stop-IfIdle([string]$Name) {
 # ---------------------------------------------------------------------------
 $script:WatcherJob = $null
 
+function Get-NotificationHostCandidates {
+    $candidates = @()
+    $pwsh = Get-Command pwsh -ErrorAction SilentlyContinue
+    if ($pwsh) {
+        $candidates += $pwsh.Source
+    }
+    $windowsPowerShell = Get-Command powershell -ErrorAction SilentlyContinue
+    if ($windowsPowerShell) {
+        $candidates += $windowsPowerShell.Source
+    }
+    return @($candidates | Select-Object -Unique)
+}
+
 function Start-NotifyWatcher {
     New-Item -ItemType Directory -Force -Path $NotifyDir | Out-Null
     $dir = $NotifyDir
-    $soundsDir = Join-Path $ProjectDir "sounds"
+    $notificationHosts = Get-NotificationHostCandidates
     $script:WatcherJob = Start-Job -ScriptBlock {
-        param($NotifyDir, $SoundsDir)
-        Add-Type -AssemblyName System.Windows.Forms
+        param($NotifyDir, $NotificationHosts)
+        $logPath = Join-Path $NotifyDir "watcher.log"
         while ($true) {
             Get-ChildItem -Path $NotifyDir -Filter "notify-*.json" -ErrorAction SilentlyContinue | ForEach-Object {
                 try {
                     $data = Get-Content $_.FullName -Raw | ConvertFrom-Json
-                    $msg = $data.message
-                    $title = $data.title
-                    $soundName = $data.sound
-                    # Try BurntToast module first, fall back to balloon tip
-                    if (Get-Module -ListAvailable -Name BurntToast -ErrorAction SilentlyContinue) {
-                        Import-Module BurntToast -ErrorAction SilentlyContinue
-                        New-BurntToastNotification -Text $title, $msg 2>$null | Out-Null
-                    } else {
-                        $notify = New-Object System.Windows.Forms.NotifyIcon
-                        $notify.Icon = [System.Drawing.SystemIcons]::Information
-                        $notify.Visible = $true
-                        $notify.ShowBalloonTip(5000, $title, $msg, [System.Windows.Forms.ToolTipIcon]::Info)
-                        Start-Sleep -Milliseconds 100
-                        $notify.Dispose()
-                    }
-                    # Play custom sound
-                    if ($soundName) {
-                        $soundPath = Join-Path $SoundsDir $soundName
-                        if (Test-Path $soundPath) {
-                            $player = New-Object System.Media.SoundPlayer $soundPath
-                            $player.Play()
+                    $sessionName = if ($data.session_name) { [string]$data.session_name } else { $null }
+                    $responsePreview = if ($data.response_preview) { [string]$data.response_preview } else { $null }
+                    $title = if ($sessionName) { $sessionName } elseif ($data.title) { [string]$data.title } else { "Hermes Gate" }
+                    $msg = if ($responsePreview) { $responsePreview } elseif ($data.message) { [string]$data.message } else { "Notification received." }
+
+                    # Visible notifications run in a separate PowerShell process so toast/UI
+                    # APIs execute in a normal user-session context instead of the background job.
+                    $escapedTitle = $title.Replace("'", "''")
+                    $escapedMsg = $msg.Replace("'", "''")
+                    $escapedLogPath = $logPath.Replace("'", "''")
+                    $notifyCommand = @"
+`$ErrorActionPreference = 'Stop'
+`$logPath = '$escapedLogPath'
+function Write-NotifyLog([string]`$entry) {
+    Add-Content -Path `$logPath -Value ((Get-Date -Format s) + ' ' + `$entry)
+}
+try {
+    if (-not (Get-Module -ListAvailable -Name BurntToast -ErrorAction SilentlyContinue)) {
+        throw 'BurntToast module not available'
+    }
+    Import-Module BurntToast -ErrorAction Stop
+    New-BurntToastNotification -Text '$escapedTitle', '$escapedMsg' 2>`$null | Out-Null
+    Write-NotifyLog 'Toast notification sent successfully'
+    exit 0
+}
+catch {
+    Write-NotifyLog ('Notification host failed: ' + `$_)
+    exit 1
+}
+"@
+                    $encodedNotifyCommand = [Convert]::ToBase64String([Text.Encoding]::Unicode.GetBytes($notifyCommand))
+
+                    $toastShown = $false
+                    foreach ($notificationHost in $NotificationHosts) {
+                        try {
+                            $process = Start-Process $notificationHost -ArgumentList @(
+                                '-NoProfile',
+                                '-WindowStyle', 'Hidden',
+                                '-EncodedCommand',
+                                $encodedNotifyCommand
+                            ) -WindowStyle Hidden -PassThru -Wait
+                            if ($process.ExitCode -eq 0) {
+                                $toastShown = $true
+                                break
+                            }
+                        }
+                        catch {
+                            Add-Content -Path $logPath -Value ((Get-Date -Format s) + ' Notification host failed: ' + $_)
                         }
                     }
-                } catch {}
+
+                    if (-not $toastShown) {
+                        Add-Content -Path $logPath -Value ((Get-Date -Format s) + ' Falling back to MessageBox')
+                        $fallbackHost = if ($NotificationHosts -and $NotificationHosts.Count -gt 0) { $NotificationHosts[0] } else { 'powershell' }
+                        $fallbackCommand = @"
+Add-Type -AssemblyName System.Windows.Forms
+[System.Windows.Forms.MessageBox]::Show('$escapedMsg', '$escapedTitle', [System.Windows.Forms.MessageBoxButtons]::OK, [System.Windows.Forms.MessageBoxIcon]::Information) | Out-Null
+"@
+                        $encodedFallbackCommand = [Convert]::ToBase64String([Text.Encoding]::Unicode.GetBytes($fallbackCommand))
+                        Start-Process $fallbackHost -ArgumentList @(
+                            '-NoProfile',
+                            '-WindowStyle', 'Hidden',
+                            '-EncodedCommand',
+                            $encodedFallbackCommand
+                        ) | Out-Null
+                    }
+                } catch {
+                    Add-Content -Path $logPath -Value ((Get-Date -Format s) + ' Watcher processing failed: ' + $_)
+                }
                 Remove-Item $_.FullName -Force -ErrorAction SilentlyContinue
             }
             Start-Sleep -Seconds 2
         }
-    } -ArgumentList $dir, $soundsDir
+    } -ArgumentList $dir, $notificationHosts
 }
 
 function Stop-NotifyWatcher {

--- a/run.ps1
+++ b/run.ps1
@@ -145,8 +145,16 @@ catch {
                                 '-WindowStyle', 'Hidden',
                                 '-EncodedCommand',
                                 $encodedNotifyCommand
-                            ) -WindowStyle Hidden -PassThru -Wait
-                            if ($process.ExitCode -eq 0) {
+                            ) -WindowStyle Hidden -PassThru
+                            if (-not $process.WaitForExit(5000)) {
+                                try {
+                                    $process.Kill()
+                                }
+                                catch {}
+                                Add-Content -Path $logPath -Value ((Get-Date -Format s) + ' Notification host timed out: ' + $notificationHost)
+                                continue
+                            }
+                            if ($null -ne $process.ExitCode -and $process.ExitCode -eq 0) {
                                 $toastShown = $true
                                 break
                             }

--- a/tests/test_notification_content.py
+++ b/tests/test_notification_content.py
@@ -60,3 +60,38 @@ async def test_check_completion_falls_back_when_response_preview_missing():
     await HermesGateApp._check_completion.__wrapped__(app)
 
     app._notify.assert_called_once_with("gate-5", "task completed")
+
+
+def test_get_preview_prefers_response_preview_then_message_preview_then_default():
+    app = HermesGateApp()
+
+    assert (
+        app._get_preview(
+            {"response_preview": "assistant reply", "message_preview": "user prompt"}
+        )
+        == "assistant reply"
+    )
+    assert app._get_preview({"message_preview": "user prompt"}) == "user prompt"
+    assert app._get_preview({}) == "task completed"
+
+
+def test_start_bg_poll_uses_notify_path_instead_of_file_only_signal() -> None:
+    app = HermesGateApp()
+    app._notify = MagicMock()
+
+    class _Mgr:
+        def __init__(self) -> None:
+            self.calls = 0
+
+        def check_completion_signals(self):
+            self.calls += 1
+            if self.calls == 1:
+                return [{"session_id": 8, "response_preview": "done"}]
+            app._bg_poll_stop.set()
+            return []
+
+    mgr = _Mgr()
+    app._start_bg_poll(mgr)
+    app._bg_poll_thread.join(timeout=2)
+
+    app._notify.assert_called_once_with("gate-8", "done")

--- a/tests/test_notification_content.py
+++ b/tests/test_notification_content.py
@@ -1,0 +1,62 @@
+from unittest.mock import MagicMock
+
+import pytest
+
+pytest.importorskip("textual")
+
+from hermes_gate.app import HermesGateApp
+
+
+def test_notify_formats_additive_payload_for_file_signal():
+    app = HermesGateApp()
+    notify_payloads = []
+
+    app._emit_host_notification = lambda title, message, sound="complete.wav", **extra: notify_payloads.append(
+        {"title": title, "message": message, "sound": sound, **extra}
+    )
+
+    app._notify("gate-7", "Assistant finished the requested fix")
+
+    assert notify_payloads == [
+        {
+            "title": "Hermes Gate",
+            "message": "Hermes gate-7: Assistant finished the requested fix",
+            "sound": "complete.wav",
+            "session_name": "gate-7",
+            "response_preview": "Assistant finished the requested fix",
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_check_completion_uses_response_preview_instead_of_message_preview():
+    app = HermesGateApp()
+    app.session_mgr = MagicMock()
+    app.session_mgr.check_completion_signals = MagicMock(
+        return_value=[
+            {
+                "session_id": 3,
+                "message_preview": "old user prompt",
+                "response_preview": "new assistant response",
+            }
+        ]
+    )
+    app._notify = MagicMock()
+
+    await HermesGateApp._check_completion.__wrapped__(app)
+
+    app._notify.assert_called_once_with("gate-3", "new assistant response")
+
+
+@pytest.mark.asyncio
+async def test_check_completion_falls_back_when_response_preview_missing():
+    app = HermesGateApp()
+    app.session_mgr = MagicMock()
+    app.session_mgr.check_completion_signals = MagicMock(
+        return_value=[{"session_id": 5}]
+    )
+    app._notify = MagicMock()
+
+    await HermesGateApp._check_completion.__wrapped__(app)
+
+    app._notify.assert_called_once_with("gate-5", "task completed")

--- a/tests/test_run_ps1.py
+++ b/tests/test_run_ps1.py
@@ -60,3 +60,92 @@ def test_readme_documents_windows_stop_command():
     """README Windows usage should stay aligned with run.ps1 command surface."""
     readme = (ROOT / "README.md").read_text(encoding="utf-8")
     assert '.\\run.ps1 stop' in readme
+
+
+def test_run_ps1_prefers_additive_session_name_and_response_preview_fields_for_windows_notifications():
+    """Windows watcher should use additive session_name/response_preview fields when present, without requiring run.sh changes."""
+    content = _run_ps1()
+    assert '$sessionName = if ($data.session_name) { [string]$data.session_name } else { $null }' in content
+    assert '$responsePreview = if ($data.response_preview) { [string]$data.response_preview } else { $null }' in content
+    assert '$title = if ($sessionName) { $sessionName } elseif ($data.title)' in content
+    assert '$msg = if ($responsePreview) { $responsePreview } elseif ($data.message)' in content
+
+
+def test_run_ps1_defaults_notification_title_and_message_before_replace_calls():
+    """Watcher should still supply safe default title/message values before escaping for detached notification hosts."""
+    content = _run_ps1()
+    assert '$title = if ($sessionName) { $sessionName } elseif ($data.title) { [string]$data.title } else { "Hermes Gate" }' in content
+    assert '$msg = if ($responsePreview) { $responsePreview } elseif ($data.message) { [string]$data.message } else { "Notification received." }' in content
+
+
+def test_run_ps1_windows_notifications_do_not_play_custom_wav_audio():
+    """Windows toast and MessageBox paths should rely on native notification sound, not SoundPlayer wav playback."""
+    content = _run_ps1()
+    assert 'System.Media.SoundPlayer' not in content
+    assert '# Play custom sound' not in content
+
+
+def test_run_ps1_logs_outer_watcher_exceptions_instead_of_swallowing_them():
+    """Top-level watcher exceptions should be recorded to watcher.log rather than silently swallowed."""
+    content = _run_ps1()
+    assert 'Watcher processing failed:' in content
+    assert '} catch {' in content
+    assert '} catch {}' not in content
+
+
+def test_run_ps1_uses_encoded_command_for_detached_notification_hosts():
+    """Windows watcher should launch child PowerShell hosts with -EncodedCommand to avoid command injection via notification text."""
+    content = _run_ps1()
+    assert "'-EncodedCommand'" in content
+    assert '$encodedNotifyCommand' in content
+    assert '$encodedFallbackCommand' in content
+
+
+def test_run_ps1_uses_detached_notification_process_for_burnttoast_and_fallback():
+    """Watcher should delegate visible notifications to a separate PowerShell process instead of invoking BurntToast directly inside the job."""
+    content = _run_ps1()
+    assert 'Start-Process $notificationHost' in content
+    assert "Get-NotificationHostCandidates" in content
+    assert 'New-BurntToastNotification' in content
+    assert '[System.Windows.Forms.MessageBox]::Show' in content
+    assert 'Import-Module BurntToast' in content
+    assert 'ShowBalloonTip' not in content
+
+
+def test_run_ps1_prefers_pwsh_before_windows_powershell_for_notifications():
+    """Adaptive notification launcher should prefer pwsh before falling back to powershell."""
+    content = _run_ps1()
+    host_candidates_idx = content.index('function Get-NotificationHostCandidates')
+    pwsh_idx = content.index("Get-Command pwsh")
+    powershell_idx = content.index("Get-Command powershell")
+    assert host_candidates_idx < pwsh_idx < powershell_idx
+
+
+def test_run_ps1_logs_notification_host_failures_before_messagebox_fallback():
+    """Fallback path should emit diagnostic logs instead of silently swallowing toast host failures."""
+    content = _run_ps1()
+    assert '$logPath = Join-Path $NotifyDir "watcher.log"' in content
+    assert 'Add-Content -Path $logPath' in content
+    assert 'Notification host failed:' in content
+    assert 'Falling back to MessageBox' in content
+
+
+def test_run_ps1_does_not_dispose_notifyicon_immediately_after_notification():
+    """The watcher should not create a short-lived NotifyIcon that disappears before the notification is visible."""
+    content = _run_ps1()
+    assert '$notify.Dispose()' not in content
+    assert 'Start-Sleep -Milliseconds 100' not in content
+
+
+def test_run_ps1_launches_notification_process_without_sound_order_dependency():
+    """Windows watcher no longer plays custom wav audio before launching native notifications."""
+    content = _run_ps1()
+    assert 'Start-Process $notificationHost' in content
+    assert '# Play custom sound' not in content
+
+
+def test_run_ps1_notification_job_no_longer_calls_burnttoast_inline():
+    """The old direct job-scoped BurntToast call shape should be gone once watcher delegates to a detached process."""
+    content = _run_ps1()
+    assert 'New-BurntToastNotification -Text $title, $msg' not in content
+    assert '$shown = $false' not in content

--- a/tests/test_run_ps1.py
+++ b/tests/test_run_ps1.py
@@ -149,3 +149,12 @@ def test_run_ps1_notification_job_no_longer_calls_burnttoast_inline():
     content = _run_ps1()
     assert 'New-BurntToastNotification -Text $title, $msg' not in content
     assert '$shown = $false' not in content
+
+
+def test_run_ps1_notification_host_wait_has_timeout_instead_of_unbounded_wait():
+    """Watcher should not block forever on Start-Process -Wait when a notification host stalls."""
+    content = _run_ps1()
+    assert '-PassThru' in content
+    assert '-Wait' not in content
+    assert 'WaitForExit(5000)' in content
+    assert '$process.Kill()' in content


### PR DESCRIPTION
## Summary

This PR hardens Windows completion notifications and adds richer completion preview payloads while keeping the existing macOS/Linux watcher contract unchanged.

## Root Cause

The Windows completion notification path had two gaps.

First, visible notification delivery was being attempted directly inside a background PowerShell job, which is fragile for toast/UI behavior and also made the detached child process launch path too dependent on interpolated command text.

Second, Hermes Gate only emitted generic notification payload fields, so the Windows watcher could not distinguish a session label from a response preview and completion handling still preferred `message_preview` even when `response_preview` was available.

## Changes

### `run.ps1`

- added `Get-NotificationHostCandidates()` to prefer `pwsh` first and then fall back to Windows PowerShell
- updated the watcher to read additive payload fields when present
  - `session_name`
  - `response_preview`
- updated title/message selection to use
  - title → `session_name` first, then existing `title`, then `"Hermes Gate"`
  - message → `response_preview` first, then existing `message`, then `"Notification received."`
- switched detached notification host launch to `-EncodedCommand`
- added watcher logging to `.notify/watcher.log`
- added detached `MessageBox` fallback when toast delivery is unavailable
- removed the previous inline watcher behavior that used
  - direct BurntToast calls inside the background job
  - short-lived balloon-tip NotifyIcon behavior
  - custom wav playback before notification delivery

### `hermes_gate/app.py`

- added `_emit_host_notification(...)` to centralize `/hermes-notify/notify-*.json` writes
- updated `_notify(...)` to emit additive payload fields
  - `session_name`
  - `response_preview`
- updated `_check_completion(...)` to prefer
  - `response_preview`
  - then `message_preview`
  - then `"task completed"`
- updated `_start_bg_poll(...)` so attached-session background polling emits the same additive payload shape as the foreground completion path

## Compatibility

This change keeps notification payloads backward-compatible.

Existing fields are still emitted

- `title`
- `message`
- `sound`

New fields are additive only

- `session_name`
- `response_preview`

Current watcher behavior is therefore

- `run.ps1`
  - prefers additive fields when present
  - falls back to legacy `title` / `message` behavior when they are absent

- `run.sh`
  - is unchanged
  - still consumes only `title` / `message` / `sound`
  - ignores the additive fields
  - therefore continues to work on the old contract without modification

## Tests

```bash
python -m pytest -q tests/test_notification_content.py tests/test_run_ps1.py
python -m compileall -q hermes_gate tests
```

Passed

- `21 passed`
- `compileall` passed
